### PR TITLE
Fix Typography tag closure

### DIFF
--- a/client/src/pages/NonVerified.js
+++ b/client/src/pages/NonVerified.js
@@ -26,6 +26,7 @@ export default function NonVerifiedPage() {
           </Typography>
           <Typography sx={{ color: 'text.secondary' }}>
             We appreciate your cooperation in verifying your email address. Please click the button below to verify your email address.
+          </Typography>
           <Box
             component="img"
             src="/assets/Images/iconImages/emailVerify.png"

--- a/client/src/pages/Page404.js
+++ b/client/src/pages/Page404.js
@@ -27,6 +27,7 @@ export default function Page404() {
           <Typography sx={{ color: 'text.secondary' }}>
             Sorry, we couldn’t find the page you’re looking for. Perhaps you’ve mistyped the URL? Be sure to check your
             spelling.
+          </Typography>
           <Box
             component="img"
             src="/assets/illustrations/illustration_404.svg"

--- a/client/src/pages/VerifyPage.js
+++ b/client/src/pages/VerifyPage.js
@@ -26,6 +26,7 @@ export default function VerifyPage() {
           </Typography>
           <Typography sx={{ color: 'text.secondary' }}>
             We appreciate your cooperation in verifying your email address. Please click the button below to verify your email address.
+          </Typography>
           <Box
             component="img"
             src="/assets/Images/covers/cover_3.jpg"


### PR DESCRIPTION
## Summary
- close Typography tags in Page404.js, VerifyPage.js, and NonVerified.js

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*