### PR TITLE
Add Babel private property plugin

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -98,6 +98,7 @@
   "devDependencies": {
     "@babel/core": "^7.19.3",
     "@babel/eslint-parser": "^7.19.1",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.0",
     "@svgr/webpack": "^6.5.0",
     "eslint": "^8.25.0",
     "eslint-config-airbnb": "^19.0.4",


### PR DESCRIPTION
## Summary
- add `@babel/plugin-proposal-private-property-in-object` to client devDependencies

## Testing
- `timeout 10 npm install`
- `timeout 10 npm test` *(fails: react-scripts not found)*