### PR TITLE
Fix styled wrappers and imports

### DIFF
--- a/client/src/sections/@dashboard/app/AppCurrentSubject.js
+++ b/client/src/sections/@dashboard/app/AppCurrentSubject.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import ReactApexChart from 'react-apexcharts';
 // @mui
+import { styled, Card, CardHeader } from '@mui/material';
 // components
 import { useChart } from '../../../components/chart';
 
@@ -15,12 +16,14 @@ const StyledChartWrapper = styled('div')(({ theme }) => ({
   },
   '& .apexcharts-canvas svg,.apexcharts-canvas foreignObject': {
     overflow: 'visible',
+  },
   '& .apexcharts-legend': {
     height: LEGEND_HEIGHT,
     alignContent: 'center',
     position: 'relative !important',
     borderTop: `solid 1px ${theme.palette.divider}`,
     top: `calc(${CHART_HEIGHT - LEGEND_HEIGHT}px) !important`,
+  },
 }));
 AppCurrentSubject.propTypes = {
   title: PropTypes.string,

--- a/client/src/sections/@dashboard/app/AppCurrentVisits.js
+++ b/client/src/sections/@dashboard/app/AppCurrentVisits.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import ReactApexChart from 'react-apexcharts';
 // @mui
+import { styled, Card, CardHeader } from '@mui/material';
 // utils
 import { fNumber } from '../../../utils/formatNumber';
 // components
@@ -22,6 +23,7 @@ const StyledChartWrapper = styled('div')(({ theme }) => ({
     position: 'relative !important',
     borderTop: `solid 1px ${theme.palette.divider}`,
     top: `calc(${CHART_HEIGHT - LEGEND_HEIGHT}px) !important`,
+  },
 }));
 AppCurrentVisits.propTypes = {
   title: PropTypes.string,


### PR DESCRIPTION
## Summary
- import MUI `styled`, `Card`, and `CardHeader`
- close styled objects for subject and visits charts

## Testing
- `npm test` *(fails: This package doesn't seem to be present in your lockfile)*
- `npm test --silent` in client *(fails: react-scripts not found)*