### PR TITLE
Fix AdminNavSection exports and imports

### DIFF
--- a/client/src/components/admin-navsection/index.js
+++ b/client/src/components/admin-navsection/index.js
@@ -1,1 +1,1 @@
-export { default} from './AdminNavSection';
+export { AdminNavSection as default } from './AdminNavSection';

--- a/client/src/layouts/dashboard/nav/index.js
+++ b/client/src/layouts/dashboard/nav/index.js
@@ -18,7 +18,7 @@ import { useLocation } from 'react-router-dom';
 import useResponsive from '../../../hooks/useResponsive';
 import Scrollbar from '../../../components/scrollbar';
 import NavSection from '../../../components/nav-section';
-import AdminNavSection from '../../../components/admin-navsection/AdminNavSection';
+import AdminNavSection from '../../../components/admin-navsection';
 import navConfig from './config';
 import AdminConfig from './AdminConfig';
 import { useAppSelector } from '../../../hooks/hooks';


### PR DESCRIPTION
## Summary
- fix corrupted export line in admin navsection component
- adjust dashboard nav to import AdminNavSection via index file

## Testing
- `npm test` *(fails: `react-scripts: not found`)*