### PR TITLE
Fix Dashboard imports

### DIFF
--- a/client/src/pages/DashboardAppPage.js
+++ b/client/src/pages/DashboardAppPage.js
@@ -1,6 +1,7 @@
 import { Helmet } from 'react-helmet-async';
 import { useEffect, useState } from 'react';
 // @mui
+import { useTheme, Container, Typography, Grid } from '@mui/material';
 
 // components
 // sections


### PR DESCRIPTION
## Summary
- clean up DashboardAppPage imports

## Testing
- `npm test --silent` *(fails: react-scripts not found)*