### PR TITLE
Fix closing tags in ProductCard

### DIFF
--- a/client/src/sections/@dashboard/products/ProductCard.js
+++ b/client/src/sections/@dashboard/products/ProductCard.js
@@ -61,6 +61,7 @@ export default function ShopProductCard({ product }) {
             </Typography>
             &nbsp;
             {fCurrency(price)}
+          </Typography>
         </Stack>
       </Stack>
     </Card>


### PR DESCRIPTION
## Summary
- add closing `Typography` tag so price section renders correctly

## Testing
- `npm test` *(fails: react-scripts not found)*