### PR TITLE
Fix missing Material UI imports

### DIFF
--- a/client/src/components/chart/styles.js
+++ b/client/src/components/chart/styles.js
@@ -1,5 +1,7 @@
 
 import { bgBlur } from '../../utils/cssStyles';
+import { useTheme, alpha } from '@mui/material/styles';
+import { GlobalStyles } from '@mui/material';
 
 export default function StyledChart() {
   const theme = useTheme();

--- a/client/src/components/chart/useChart.js
+++ b/client/src/components/chart/useChart.js
@@ -1,5 +1,6 @@
 
 import merge from 'lodash/merge';
+import { useTheme, alpha } from '@mui/material/styles';
 
 export default function useChart(options = {}) {
   const theme = useTheme();

--- a/client/src/components/label/Label.js
+++ b/client/src/components/label/Label.js
@@ -1,8 +1,8 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import PropTypes from 'prop-types';
 import { forwardRef } from 'react';
 // @mui
-//
+import { useTheme } from '@mui/material/styles';
+import { Box } from '@mui/material';
 import { StyledLabel } from './styles';
 
 // ----------------------------------------------------------------------

--- a/client/src/components/logo/Logo.js
+++ b/client/src/components/logo/Logo.js
@@ -1,8 +1,9 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import PropTypes from 'prop-types';
 import { forwardRef } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 // @mui
+import { useTheme } from '@mui/material/styles';
+import { Box, Link } from '@mui/material';
 
 // ----------------------------------------------------------------------
 const Logo = forwardRef(({ disabledLink = false, sx, ...other }, ref) => {

--- a/client/src/hooks/useResponsive.js
+++ b/client/src/hooks/useResponsive.js
@@ -1,5 +1,8 @@
 
 
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
 export default function useResponsive(query, start, end) {
   const theme = useTheme();
 

--- a/client/src/layouts/dashboard/DashboardLayout.js
+++ b/client/src/layouts/dashboard/DashboardLayout.js
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 // @mui
+import { styled } from '@mui/material/styles';
 
 import Header from './header';
 import Nav from './nav';

--- a/client/src/layouts/simple/SimpleLayout.js
+++ b/client/src/layouts/simple/SimpleLayout.js
@@ -1,6 +1,7 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import { Outlet } from 'react-router-dom';
 // @mui
+import { styled } from '@mui/material/styles';
+import { Box } from '@mui/material';
 // components
 import Logo from '../../components/logo';
 

--- a/client/src/pages/BlogPage.js
+++ b/client/src/pages/BlogPage.js
@@ -1,6 +1,6 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import { Helmet } from 'react-helmet-async';
 // @mui
+import { Container, Stack, Typography, Grid } from '@mui/material';
 // components
 import Iconify from '../components/iconify';
 import { BlogPostCard, BlogPostsSort, BlogPostsSearch } from '../sections/@dashboard/blog';

--- a/client/src/pages/DealsPage.js
+++ b/client/src/pages/DealsPage.js
@@ -1,6 +1,7 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import React from 'react'; // Import React as a whole without destructuring
 import { Helmet } from 'react-helmet-async';
+// @mui
+import { Container, Card, Box, Button, Dialog, DialogTitle, DialogContent, DialogActions, TextField } from '@mui/material';
 import { useDropzone } from 'react-dropzone';
 
 import DealsData from '../components/dataGrid/DealsData'; // Assuming this is your chart

--- a/client/src/pages/NonVerified.js
+++ b/client/src/pages/NonVerified.js
@@ -1,7 +1,7 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import { Helmet } from 'react-helmet-async';
 // @mui
-
+import { styled } from '@mui/material/styles';
+import { Container, Typography, Box } from '@mui/material';
 // ----------------------------------------------------------------------
 const StyledContent = styled('div')(({ theme }) => ({
   maxWidth: 480,

--- a/client/src/pages/Page404.js
+++ b/client/src/pages/Page404.js
@@ -1,8 +1,8 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import { Helmet } from 'react-helmet-async';
 import { Link as RouterLink } from 'react-router-dom';
 // @mui
-
+import { styled } from '@mui/material/styles';
+import { Button, Box, Container, Typography } from '@mui/material';
 // ----------------------------------------------------------------------
 const StyledContent = styled('div')(({ theme }) => ({
   maxWidth: 480,

--- a/client/src/pages/PayPage.js
+++ b/client/src/pages/PayPage.js
@@ -1,6 +1,7 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import * as React from 'react';
 import { Helmet } from 'react-helmet-async';
+// @mui
+import { Container, Card, Box } from '@mui/material';
 import PayrollData from '../components/dataGrid/PayrollData';
 import LeadGenPay from '../components/dataGrid/LeadGenPay';
 import { useAppSelector } from '../hooks/hooks';

--- a/client/src/pages/ProductsPage.js
+++ b/client/src/pages/ProductsPage.js
@@ -1,7 +1,7 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import { Helmet } from 'react-helmet-async';
 import { useState } from 'react';
 // @mui
+import { Container, Typography, Stack } from '@mui/material';
 // components
 import { ProductSort, ProductList, ProductCartWidget, ProductFilterSidebar } from '../sections/@dashboard/products';
 // mock

--- a/client/src/pages/VerifyPage.js
+++ b/client/src/pages/VerifyPage.js
@@ -1,8 +1,8 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import { Helmet } from 'react-helmet-async';
 import { Link as RouterLink } from 'react-router-dom';
 // @mui
-
+import { styled } from '@mui/material/styles';
+import { Container, Typography, Button, Box } from '@mui/material';
 // ----------------------------------------------------------------------
 const StyledContent = styled('div')(({ theme }) => ({
   maxWidth: 480,

--- a/client/src/sections/@dashboard/app/AppCurrentVisits.js
+++ b/client/src/sections/@dashboard/app/AppCurrentVisits.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import ReactApexChart from 'react-apexcharts';
 // @mui
 import { styled, Card, CardHeader } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 // utils
 import { fNumber } from '../../../utils/formatNumber';
 // components

--- a/client/src/sections/@dashboard/app/AppWidgetSummary.js
+++ b/client/src/sections/@dashboard/app/AppWidgetSummary.js
@@ -1,5 +1,7 @@
 // @mui
 import PropTypes from 'prop-types';
+import { styled, alpha } from '@mui/material/styles';
+import { Card, Typography } from '@mui/material';
 // utils
 import { fShortenNumber } from '../../../utils/formatNumber';
 // components

--- a/client/src/sections/@dashboard/products/ProductCard.js
+++ b/client/src/sections/@dashboard/products/ProductCard.js
@@ -1,6 +1,7 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
 import PropTypes from 'prop-types';
 // @mui
+import { styled } from '@mui/material/styles';
+import { Card, Box, Stack, Link, Typography } from '@mui/material';
 // utils
 import { fCurrency } from '../../../utils/formatNumber';
 // components

--- a/client/src/sections/@dashboard/products/ProductCartWidget.js
+++ b/client/src/sections/@dashboard/products/ProductCartWidget.js
@@ -1,4 +1,6 @@
 // @mui
+import { styled } from '@mui/material/styles';
+import { Badge } from '@mui/material';
 // component
 import Iconify from '../../../components/iconify';
 

--- a/client/src/theme/globalStyles.js
+++ b/client/src/theme/globalStyles.js
@@ -1,4 +1,5 @@
 // @mui
+import { GlobalStyles as MUIGlobalStyles } from '@mui/material';
 
 // ----------------------------------------------------------------------
 export default function GlobalStyles() {


### PR DESCRIPTION
## Summary
- add missing Material UI imports in various components and pages
- ensure hooks and global styles load required utilities

## Testing
- `npm test` *(fails: react-scripts not found)*