### PR TITLE
Fix setup script commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ To run both together:
 
 ```bash
 npm run dev
+# or simply
+npm start
 ```
 
 ## Tests

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "dev": "concurrently \"cross-env NODE_ENV=development npm run server\" \"npm run client\"",
+    "start": "npm run dev",
     "server": "cd server && npm run dev",
     "client": "cd client && npm run dev",
     "test": "npm test --workspaces"

--- a/server/package.json
+++ b/server/package.json
@@ -117,7 +117,7 @@
     "packageManager": "yarn"
   },
   "engines": {
-  "node": "18.x" 
+    "node": ">=18 <=20"
   }
 
  


### PR DESCRIPTION
## Summary
- add a `start` alias so `npm start` works
- loosen server engines field
- note `npm start` in README

## Testing
- `npm test` *(fails: react-scripts not found)*