### PR TITLE
Fix ColorPreview imports

### DIFF
--- a/client/src/components/color-utils/ColorPreview.js
+++ b/client/src/components/color-utils/ColorPreview.js
@@ -1,6 +1,7 @@
-import { Button, Input, Box, Stack, Heading } from "@chakra-ui/react";
+import { Box, Stack, Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 // @mui
+import { alpha } from '@mui/material/styles';
 
 // ----------------------------------------------------------------------
 ColorPreview.propTypes = {


### PR DESCRIPTION
## Summary
- swap the Chakra import in `ColorPreview.js` for the proper MUI one
- bring in `alpha` helper from MUI styles

## Testing
- `npm test` *(fails: react-scripts not found)*