### PR TITLE
Add MUI imports for dialogs

### DIFF
--- a/client/src/pages/DealsPage.js
+++ b/client/src/pages/DealsPage.js
@@ -2,6 +2,7 @@ import React from 'react'; // Import React as a whole without destructuring
 import { Helmet } from 'react-helmet-async';
 // @mui
 import { Container, Card, Box, Button, Dialog, DialogTitle, DialogContent, DialogActions, TextField } from '@mui/material';
+import { InsertDriveFile as InsertDriveFileIcon } from '@mui/icons-material';
 import { useDropzone } from 'react-dropzone';
 
 import DealsData from '../components/dataGrid/DealsData'; // Assuming this is your chart

--- a/client/src/pages/PreviousPay.js
+++ b/client/src/pages/PreviousPay.js
@@ -1,7 +1,8 @@
-import { Button } from "@chakra-ui/react";
 import React from 'react'; // Import React as a whole without destructuring
 import { Helmet } from 'react-helmet-async';
 import { useDropzone } from 'react-dropzone';
+import { Container, Card, Button, Dialog, DialogTitle, DialogContent, DialogActions } from '@mui/material';
+import { InsertDriveFile as InsertDriveFileIcon } from '@mui/icons-material';
 
 import DealsData from '../components/dataGrid/DealsData'; // Assuming this is your chart
 import PreviousgPayData from '../components/dataGrid/PreviousPayData';

--- a/client/src/pages/UpcomingPayPge.js
+++ b/client/src/pages/UpcomingPayPge.js
@@ -1,7 +1,8 @@
-import { Button } from "@chakra-ui/react";
 import React from 'react'; // Import React as a whole without destructuring
 import { Helmet } from 'react-helmet-async';
 import { useDropzone } from 'react-dropzone';
+import { Container, Card, Button, Dialog, DialogTitle, DialogContent, DialogActions } from '@mui/material';
+import { InsertDriveFile as InsertDriveFileIcon } from '@mui/icons-material';
 
 import DealsData from '../components/dataGrid/DealsData'; // Assuming this is your chart
 import UpcomingPayData from '../components/dataGrid/UpcomingPay';


### PR DESCRIPTION
## Summary
- add `InsertDriveFile` icon import alias
- ensure pages use `Container`, `Card`, and dialog components from MUI
- remove leftover Chakra imports

## Testing
- `npm test` *(fails: react-scripts not found)*