### PR TITLE
Fix blog component imports

### DIFF
--- a/client/src/sections/@dashboard/blog/BlogPostsSearch.js
+++ b/client/src/sections/@dashboard/blog/BlogPostsSearch.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 
 // @mui
+import { styled } from '@mui/material/styles';
+import { Popper, Autocomplete, TextField, InputAdornment } from '@mui/material';
+
 // components
 import Iconify from '../../../components/iconify';
 // ----------------------------------------------------------------------

--- a/client/src/sections/@dashboard/blog/BlogPostsSort.js
+++ b/client/src/sections/@dashboard/blog/BlogPostsSort.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 // @mui
+import { TextField, MenuItem } from '@mui/material';
 
 // ----------------------------------------------------------------------
 BlogPostsSort.propTypes = {


### PR DESCRIPTION
## Summary
- add MUI imports to BlogPostsSearch
- add missing TextField/MenuItem imports to BlogPostsSort

## Testing
- `npm test --silent` *(fails: react-scripts not found)*