### PR TITLE
Fix bgBlur backdrop constant

### DIFF
--- a/client/src/utils/cssStyles.js
+++ b/client/src/utils/cssStyles.js
@@ -1,13 +1,15 @@
 
 
 // @mui
+import { alpha } from '@mui/material/styles';
 
 // ----------------------------------------------------------------------
-export function bgBlur(props) {
-  const color = props?.color || '#000000';
-  const blur = props?.blur || 6;
-  const opacity = props?.opacity || 0.8;
-  const imgUrl = props?.imgUrl;
+export function bgBlur({ color = '#000000', blur = 6, opacity = 0.8, imgUrl } = {}) {
+  const backdrop = {
+    backgroundColor: alpha(color, opacity),
+    backdropFilter: `blur(${blur}px)`,
+    WebkitBackdropFilter: `blur(${blur}px)`,
+  };
   if (imgUrl) {
     return {
       position: 'relative',


### PR DESCRIPTION
## Summary
- import `alpha` from MUI
- define a `backdrop` constant using blur and opacity
- use this constant in `bgBlur`

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*