### PR TITLE
Switch to MUI theme provider

### DIFF
--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -1,41 +1,27 @@
 import React from 'react';
-import { ChakraProvider, extendTheme, theme as baseTheme } from '@chakra-ui/react';
+import { CssBaseline } from '@mui/material';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
 
-export const theme = extendTheme({
-  colors: {
-    ...baseTheme.colors,
-    sand: {
-      50: '#fdf7f0',
-      100: '#f9e8d2',
-      200: '#f2d1a6',
-      300: '#e9ba79',
-      400: '#e1a44d',
-      500: '#c88a33',
-      600: '#9d6d26',
-      700: '#725019',
-      800: '#47330c',
-      900: '#1f1600'
-    }
-  },
-  space: {
-    px: '1px',
-    1: '4px',
-    2: '8px',
-    3: '12px',
-    4: '16px',
-    5: '20px',
-    6: '24px'
-  },
-  radii: {
-    ...baseTheme.radii,
-    '2xl': '1rem'
-  },
-  shadows: {
-    ...baseTheme.shadows,
-    soft: '0 2px 4px rgba(0,0,0,0.08)'
-  }
-});
+import palette from './theme/palette';
+import typography from './theme/typography';
+import shadows from './theme/shadows';
+import customShadows from './theme/customShadows';
+import ComponentsOverrides from './theme/overrides';
 
-export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  return React.createElement(ChakraProvider, { theme }, children);
+export default function ThemeProviderWrapper({ children }: { children: React.ReactNode }) {
+  const theme = createTheme({
+    palette,
+    typography,
+    shadows: shadows(),
+  });
+
+  theme.components = ComponentsOverrides(theme);
+  (theme as any).customShadows = customShadows();
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
 }


### PR DESCRIPTION
## Summary
- replace the Chakra-based `ThemeProvider` with a Material UI configuration

## Testing
- `npm test --silent` *(fails: react-scripts not found)*