### PR TITLE
Fix global styles object structure

### DIFF
--- a/client/src/theme/globalStyles.js
+++ b/client/src/theme/globalStyles.js
@@ -15,8 +15,17 @@ export default function GlobalStyles() {
           width: '100%',
           height: '100%',
           WebkitOverflowScrolling: 'touch',
+        },
         body: {
+          margin: 0,
+          padding: 0,
+          width: '100%',
+          height: '100%',
+        },
         '#root': {
+          width: '100%',
+          height: '100%',
+        },
         input: {
           '&[type=number]': {
             MozAppearance: 'textfield',
@@ -25,13 +34,22 @@ export default function GlobalStyles() {
               WebkitAppearance: 'none',
             },
             '&::-webkit-inner-spin-button': {
+              margin: 0,
+              WebkitAppearance: 'none',
+            },
           },
+        },
         img: {
           display: 'block',
           maxWidth: '100%',
+        },
         ul: {
+          margin: 0,
+          padding: 0,
+        },
       }}
     />
   );
+
   return inputGlobalStyles;
 }


### PR DESCRIPTION
## Summary
- properly close nested style rules in globalStyles
- return MUIGlobalStyles component from `GlobalStyles`

## Testing
- `npm --workspace client run lint` *(fails: ESLint config missing)*
- `npm test --silent` *(fails: react-scripts not found)*