### PR TITLE
Add alpha imports for shadow utils

### DIFF
--- a/client/src/theme/customShadows.js
+++ b/client/src/theme/customShadows.js
@@ -1,5 +1,6 @@
 // @mui
 //
+import { alpha } from '@mui/material/styles';
 import palette from './palette';
 
 // ----------------------------------------------------------------------

--- a/client/src/theme/shadows.js
+++ b/client/src/theme/shadows.js
@@ -1,5 +1,6 @@
 // @mui
 //
+import { alpha } from '@mui/material/styles';
 import palette from './palette';
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- import `alpha` in shadow helpers

## Testing
- `npm run lint` (fails: ESLint couldn't find a config)
- `npm run test:lint` in server (fails: ESLint couldn't find a config)
