### PR TITLE
Fix alpha imports

### DIFF
--- a/client/src/theme/overrides/Backdrop.js
+++ b/client/src/theme/overrides/Backdrop.js
@@ -1,5 +1,6 @@
 
 // ----------------------------------------------------------------------
+import { alpha } from '@mui/material/styles';
 export default function Backdrop(theme) {
   return {
     MuiBackdrop: {

--- a/client/src/theme/overrides/Button.js
+++ b/client/src/theme/overrides/Button.js
@@ -1,4 +1,5 @@
 // ----------------------------------------------------------------------
+import { alpha } from '@mui/material/styles';
 export default function Button(theme) {
   return {
     MuiButton: {

--- a/client/src/theme/overrides/Input.js
+++ b/client/src/theme/overrides/Input.js
@@ -1,4 +1,5 @@
 // ----------------------------------------------------------------------
+import { alpha } from '@mui/material/styles';
 export default function Input(theme) {
   return {
     MuiInputBase: {

--- a/client/src/theme/palette.js
+++ b/client/src/theme/palette.js
@@ -1,5 +1,6 @@
 
 // ----------------------------------------------------------------------
+import { alpha } from '@mui/material/styles';
 // SETUP COLORS
 const GREY = {
   0: '#FFFFFF',


### PR DESCRIPTION
## Summary
- import `alpha` from MUI styles for palette and component overrides

## Testing
- `npm test` *(fails: react-scripts not found)*