### PR TITLE
Add RootComponent export and test

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -37,7 +37,7 @@ const loadGoogleMapsAPI = (callback?: () => void) => {
   }
 };
 
-const RootComponent = () => {
+export const RootComponent = () => {
   useEffect(() => {
     loadGoogleMapsAPI(() => {
     });
@@ -56,9 +56,13 @@ const RootComponent = () => {
   );
 };
 
-// Render the root component
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(<RootComponent />);
+// Render the root component when not running tests
+if (process.env.NODE_ENV !== 'test') {
+  const root = ReactDOM.createRoot(
+    document.getElementById('root') as HTMLElement
+  );
+  root.render(<RootComponent />);
+}
 
 
 

--- a/tests/client/root/RootComponent.test.tsx
+++ b/tests/client/root/RootComponent.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { RootComponent } from '../../../client/src/index';
+
+describe('RootComponent', () => {
+  it('renders login page by default', () => {
+    render(<RootComponent />);
+    expect(screen.getByText(/login/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- export `RootComponent` for easier testing
- avoid automatic render during tests
- add a smoke test for the root React component

## Testing
- `npm test` *(fails: react-scripts not found)*