### PR TITLE
Switch Chakra wrappers to MUI styled

### DIFF
--- a/client/src/components/nav-section/styles.js
+++ b/client/src/components/nav-section/styles.js
@@ -1,26 +1,23 @@
-import { chakra } from '@chakra-ui/react';
+import { styled } from '@mui/material/styles';
 
-export const StyledNavItem = chakra('a', {
-  baseStyle: {
-    display: 'flex',
-    alignItems: 'center',
-    height: '48px',
-    position: 'relative',
-    textTransform: 'capitalize',
-    color: 'gray.600',
-    borderRadius: 'md',
-    px: 2,
-  },
-});
+export const StyledNavItem = styled('a')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  height: '48px',
+  position: 'relative',
+  textTransform: 'capitalize',
+  color: theme.palette.grey[600],
+  borderRadius: theme.shape.borderRadius,
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+}));
 
-export const StyledNavItemIcon = chakra('div', {
-  baseStyle: {
-    width: '22px',
-    height: '22px',
-    color: 'inherit',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    mr: 2,
-  },
-});
+export const StyledNavItemIcon = styled('div')(({ theme }) => ({
+  width: '22px',
+  height: '22px',
+  color: 'inherit',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginRight: theme.spacing(2),
+}));

--- a/client/src/layouts/dashboard/header/Searchbar.js
+++ b/client/src/layouts/dashboard/header/Searchbar.js
@@ -1,32 +1,32 @@
 import React, { useState } from 'react';
-import { chakra, Input, IconButton, Slide, InputGroup, InputLeftElement, useOutsideClick } from '@chakra-ui/react';
+import { Input, IconButton, Slide, InputGroup, InputLeftElement, useOutsideClick } from '@chakra-ui/react';
+import { styled, alpha } from '@mui/material/styles';
 import { Box } from '@mui/material';
-import { transparentize } from '@chakra-ui/theme-tools';
 import Iconify from '../../../components/iconify';
 
 const HEADER_MOBILE = 64;
 const HEADER_DESKTOP = 92;
 
-const StyledSearchbar = chakra('div', {
-  baseStyle: {
-    top: 0,
-    left: 0,
-    zIndex: 99,
-    width: '100%',
-    display: 'flex',
-    position: 'absolute',
-    alignItems: 'center',
-    height: `${HEADER_MOBILE}px`,
-    px: 3,
-    bg: (theme) => transparentize(theme.colors.white, 0.2),
-    backdropFilter: 'blur(6px)',
-    boxShadow: 'md',
-    '@media (min-width: 48em)': {
-      height: `${HEADER_DESKTOP}px`,
-      px: 5,
-    },
+const StyledSearchbar = styled('div')(({ theme }) => ({
+  top: 0,
+  left: 0,
+  zIndex: 99,
+  width: '100%',
+  display: 'flex',
+  position: 'absolute',
+  alignItems: 'center',
+  height: `${HEADER_MOBILE}px`,
+  paddingLeft: theme.spacing(3),
+  paddingRight: theme.spacing(3),
+  backgroundColor: alpha(theme.palette.common.white, 0.2),
+  backdropFilter: 'blur(6px)',
+  boxShadow: theme.shadows[3],
+  '@media (min-width: 48em)': {
+    height: `${HEADER_DESKTOP}px`,
+    paddingLeft: theme.spacing(5),
+    paddingRight: theme.spacing(5),
   },
-});
+}));
 
 export default function Searchbar() {
   const [open, setOpen] = useState(false);

--- a/client/src/layouts/dashboard/nav/index.js
+++ b/client/src/layouts/dashboard/nav/index.js
@@ -9,10 +9,9 @@ import {
   Text,
   Link,
   Button,
-  chakra,
 } from '@chakra-ui/react';
+import { styled, alpha } from '@mui/material/styles';
 import { Box } from '@mui/material';
-import { transparentize } from '@chakra-ui/theme-tools';
 import { useLocation } from 'react-router-dom';
 import useResponsive from '../../../hooks/useResponsive';
 import Scrollbar from '../../../components/scrollbar';
@@ -26,15 +25,13 @@ import account from '../../../_mock/account';
 
 const NAV_WIDTH = 280;
 
-const StyledAccount = chakra('div', {
-  baseStyle: {
-    display: 'flex',
-    alignItems: 'center',
-    p: 2,
-    borderRadius: 'md',
-    bg: (theme) => transparentize(theme.colors.gray[500], 0.12),
-  },
-});
+const StyledAccount = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  padding: theme.spacing(2),
+  borderRadius: theme.shape.borderRadius,
+  backgroundColor: alpha(theme.palette.grey[500], 0.12),
+}));
 
 Nav.propTypes = {
   openNav: PropTypes.bool,


### PR DESCRIPTION
## Summary
- replace `chakra('a'...)` and `chakra('div'...)` usages with MUI `styled`
- recreate style definitions using the MUI styled API

## Testing
- `npm test` *(fails: react-scripts not found)*