### PR TITLE
Replace Chakra Alert with MUI

### DIFF
--- a/client/src/components/alert/Alert.tsx
+++ b/client/src/components/alert/Alert.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { Alert, AlertIcon, Collapse, CloseButton } from '@chakra-ui/react';
+import Alert from '@mui/material/Alert';
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
 
 export interface AlertProps {
   open: boolean;
@@ -10,10 +13,22 @@ export interface AlertProps {
 
 const AlertComponent: React.FC<AlertProps> = ({ open, message, type = 'info', onClose }) => (
   <Collapse in={open} style={{ position: 'fixed', top: '1rem', right: '1rem', zIndex: 1400 }}>
-    <Alert status={type} variant="solid" borderRadius="md" color="white">
-      <AlertIcon />
+    <Alert
+      severity={type}
+      variant="filled"
+      sx={{ borderRadius: '4px', color: 'white', position: 'relative' }}
+    >
       {message}
-      {onClose && <CloseButton position="absolute" right="8px" top="8px" onClick={onClose} />}
+      {onClose && (
+        <IconButton
+          aria-label="close"
+          size="small"
+          onClick={onClose}
+          sx={{ position: 'absolute', right: 8, top: 8, color: 'inherit' }}
+        >
+          <CloseIcon fontSize="inherit" />
+        </IconButton>
+      )}
     </Alert>
   </Collapse>
 );


### PR DESCRIPTION
## Summary
- swap Chakra UI alert implementation for MUI
- map Chakra `status` prop to MUI `severity`

## Testing
- `npm test` *(fails: react-scripts not found)*