### PR TITLE
Replace Chakra menus with MUI

### DIFF
--- a/client/src/layouts/dashboard/header/AccountPopover.js
+++ b/client/src/layouts/dashboard/header/AccountPopover.js
@@ -1,17 +1,15 @@
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import {
   Avatar,
   Divider,
   IconButton,
   Menu,
-  MenuButton,
   MenuItem,
-  MenuList,
   Stack,
-  Text,
-  useDisclosure,
-} from '@chakra-ui/react';
-import { Box } from '@mui/material';
+  Typography,
+  Box,
+} from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import account from '../../../_mock/account';
 
@@ -30,38 +28,57 @@ MenuOption.propTypes = {
 
 export default function AccountPopover({ onLogout }) {
   const navigate = useNavigate();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
   const handleLogout = () => {
-    onClose();
+    handleClose();
     if (onLogout) onLogout();
     navigate('/login', { replace: true });
   };
 
+  const open = Boolean(anchorEl);
+
   return (
-    <Menu isOpen={isOpen} onClose={onClose} placement="bottom-end">
-      <MenuButton as={IconButton} onClick={onOpen} p={0}>
+    <>
+      <IconButton onClick={handleOpen} sx={{ p: 0 }}>
         <Avatar src={account.photoURL} alt="account" />
-      </MenuButton>
-      <MenuList p={0} mt={1.5} ml={0.75} w="180px">
-        <Box my={1.5} px={2.5}>
-          <Text fontWeight="semibold" noOfLines={1}>
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        PaperProps={{ sx: { p: 0, mt: 1.5, ml: 0.75, width: 180 } }}
+      >
+        <Box sx={{ my: 1.5, px: 2.5 }}>
+          <Typography variant="subtitle2" noWrap>
             {account.displayName}
-          </Text>
-          <Text fontSize="sm" color="gray.500" noOfLines={1}>
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'text.secondary' }} noWrap>
             {account.email}
-          </Text>
+          </Typography>
         </Box>
-        <Divider borderStyle="dashed" />
-        <Stack p={1}>
-          <MenuOption label="Profile" onClick={() => navigate('/dashboard/app')} />
+        <Divider sx={{ borderStyle: 'dashed' }} />
+        <Stack sx={{ p: 1 }}>
+          <MenuItem onClick={() => { handleClose(); navigate('/dashboard/app'); }}>
+            Profile
+          </MenuItem>
         </Stack>
-        <Divider borderStyle="dashed" />
-        <MenuItem onClick={handleLogout} m={1}>
+        <Divider sx={{ borderStyle: 'dashed' }} />
+        <MenuItem onClick={handleLogout} sx={{ m: 1 }}>
           Logout
         </MenuItem>
-      </MenuList>
-    </Menu>
+      </Menu>
+    </>
   );
 }
 

--- a/client/src/layouts/dashboard/header/LanguagePopover.js
+++ b/client/src/layouts/dashboard/header/LanguagePopover.js
@@ -1,14 +1,12 @@
+import { useState } from 'react';
 import {
   IconButton,
   Menu,
-  MenuButton,
-  MenuList,
   MenuItem,
   Stack,
-  useDisclosure,
-} from '@chakra-ui/react';
-import { Box } from '@mui/material';
-import { transparentize } from '@chakra-ui/theme-tools';
+  Box,
+} from '@mui/material';
+import { alpha } from '@mui/material/styles';
 
 const LANGS = [
   {
@@ -24,30 +22,55 @@ const LANGS = [
 ];
 
 export default function LanguagePopover() {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
 
   return (
-    <Menu isOpen={isOpen} onClose={onClose} placement="bottom-end">
-      <MenuButton
-        as={IconButton}
-        onClick={onOpen}
-        p={0}
-        w="44px"
-        h="44px"
-        bg={isOpen ? (theme) => transparentize(theme.colors.primary[500], 0.12) : undefined}
+    <>
+      <IconButton
+        onClick={handleOpen}
+        sx={{
+          p: 0,
+          width: 44,
+          height: 44,
+          ...(open && {
+            bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12),
+          }),
+        }}
       >
         <img src={LANGS[0].icon} alt={LANGS[0].label} />
-      </MenuButton>
-      <MenuList p={1} mt={1.5} ml={0.75} w="180px">
+      </IconButton>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        PaperProps={{ sx: { p: 1, mt: 1.5, ml: 0.75, width: 180 } }}
+      >
         <Stack spacing={0.75}>
           {LANGS.map((option) => (
-            <MenuItem key={option.value} onClick={onClose} isDisabled={option.value === LANGS[0].value}>
-              <Box as="img" alt={option.label} src={option.icon} w={28} mr={2} />
+            <MenuItem
+              key={option.value}
+              onClick={handleClose}
+              disabled={option.value === LANGS[0].value}
+            >
+              <Box component="img" alt={option.label} src={option.icon} sx={{ width: 28, mr: 2 }} />
               {option.label}
             </MenuItem>
           ))}
         </Stack>
-      </MenuList>
-    </Menu>
+      </Menu>
+    </>
   );
 }

--- a/client/src/layouts/dashboard/header/NotificationsPopover.js
+++ b/client/src/layouts/dashboard/header/NotificationsPopover.js
@@ -3,19 +3,14 @@ import { faker } from '@faker-js/faker';
 import {
   IconButton,
   Popover,
-  PopoverTrigger,
-  PopoverContent,
-  PopoverArrow,
-  PopoverBody,
-  Text,
+  Typography,
   List,
   ListItem,
   Divider,
   Tooltip,
   Badge,
-  useDisclosure,
-} from '@chakra-ui/react';
-import { Box } from '@mui/material';
+  Box,
+} from '@mui/material';
 import Iconify from '../../../components/iconify';
 
 const mockNotifications = [...Array(3)].map(() => ({
@@ -26,60 +21,69 @@ const mockNotifications = [...Array(3)].map(() => ({
 }));
 
 export default function NotificationsPopover() {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [anchorEl, setAnchorEl] = useState(null);
   const [notifications, setNotifications] = useState(mockNotifications);
 
+  const open = Boolean(anchorEl);
   const totalUnRead = notifications.length;
+
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
   const handleMarkAllAsRead = () => {
     setNotifications([]);
   };
 
   return (
-    <Popover isOpen={isOpen} onClose={onClose} placement="bottom-end">
-      <PopoverTrigger>
-        <IconButton onClick={onOpen} w={40} h={40} colorScheme={isOpen ? 'blue' : 'gray'}>
-          {totalUnRead > 0 && (
-            <Badge position="absolute" top="0" right="0" colorScheme="red">
-              {totalUnRead}
-            </Badge>
-          )}
+    <>
+      <IconButton onClick={handleOpen} sx={{ width: 40, height: 40, color: open ? 'primary.main' : 'inherit' }}>
+        <Badge color="error" badgeContent={totalUnRead} invisible={totalUnRead === 0}>
           <Iconify icon="eva:bell-fill" />
-        </IconButton>
-      </PopoverTrigger>
-      <PopoverContent mt={1.5} ml={0.75} w="360px">
-        <PopoverArrow />
-        <PopoverBody p={0}>
-          <Box display="flex" alignItems="center" py={2} px={2.5}>
-            <Box sx={{ flexGrow: 1 }}>
-            <Text fontWeight="semibold">Notifications</Text>
-            <Text fontSize="sm" color="gray.500">
+        </Badge>
+      </IconButton>
+
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        PaperProps={{ sx: { mt: 1.5, ml: 0.75, width: 360 } }}
+      >
+        <Box display="flex" alignItems="center" py={2} px={2.5}>
+          <Box sx={{ flexGrow: 1 }}>
+            <Typography variant="subtitle2">Notifications</Typography>
+            <Typography variant="body2" color="text.secondary">
               You have {totalUnRead} unread messages
-            </Text>
+            </Typography>
           </Box>
           {totalUnRead > 0 && (
-            <Tooltip label="Mark all as read">
-              <IconButton colorScheme="blue" onClick={handleMarkAllAsRead}>
+            <Tooltip title="Mark all as read">
+              <IconButton color="primary" onClick={handleMarkAllAsRead}>
                 <Iconify icon="eva:done-all-fill" />
               </IconButton>
             </Tooltip>
           )}
         </Box>
-        <Divider borderStyle="dashed" />
-        <List spacing={0} p={0} m={0}>
+        <Divider sx={{ borderStyle: 'dashed' }} />
+        <List disablePadding>
           {notifications.map((notification) => (
-            <ListItem key={notification.id} py={2} px={4} borderBottomWidth="1px">
+            <ListItem key={notification.id} sx={{ py: 2, px: 4, borderBottomWidth: 1, borderBottomStyle: 'solid', borderColor: 'divider' }}>
               <Box>
-                <Text fontWeight="medium">{notification.title}</Text>
-                <Text fontSize="sm" color="gray.500">
+                <Typography variant="subtitle2">{notification.title}</Typography>
+                <Typography variant="body2" color="text.secondary">
                   {notification.description}
-                </Text>
+                </Typography>
               </Box>
             </ListItem>
           ))}
         </List>
-        </PopoverBody>
-      </PopoverContent>
-    </Popover>
+      </Popover>
+    </>
   );
 }

--- a/client/src/layouts/dashboard/header/index.js
+++ b/client/src/layouts/dashboard/header/index.js
@@ -64,12 +64,8 @@ export default function Header({ onOpenNav }) {
           Upload Bill
         </Button>
 
-        <IconButton mr={1}>
-          <NotificationsPopover />
-        </IconButton>
-        <IconButton mr={1}>
-          <LanguagePopover />
-        </IconButton>
+        <NotificationsPopover />
+        <LanguagePopover />
         <AccountPopover />
       </StyledToolbar>
 


### PR DESCRIPTION
## Summary
- migrate dashboard menu and popover components from Chakra UI to MUI
- simplify popover triggers in Header

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*