### PR TITLE
Replace Chakra components with MUI

### DIFF
--- a/client/src/components/admin-navsection/AdminNavSection.js
+++ b/client/src/components/admin-navsection/AdminNavSection.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { NavLink as RouterLink } from 'react-router-dom';
-import { List, Text } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { List } from '@chakra-ui/react';
+import { Box, Typography } from '@mui/material';
 import { StyledNavItem, StyledNavItemIcon } from '../nav-section/styles';
 import { useAppSelector } from '../../hooks/hooks';
 import { authSelector } from '../../redux/slice/authSlice';
@@ -37,7 +37,7 @@ function NavItem({ item }) {
       _active={{ color: 'gray.800', bg: 'gray.100', fontWeight: 'bold' }}
     >
       <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
-      <Text>{title}</Text>
+      <Typography>{title}</Typography>
       {info && info}
     </StyledNavItem>
   );

--- a/client/src/components/nav-section/NavSection.js
+++ b/client/src/components/nav-section/NavSection.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { NavLink as RouterLink } from 'react-router-dom';
-import { List, Text } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { List } from '@chakra-ui/react';
+import { Box, Typography } from '@mui/material';
 import { StyledNavItem, StyledNavItemIcon } from './styles';
 import { useAppSelector } from '../../hooks/hooks';
 import { authSelector } from '../../redux/slice/authSlice';
@@ -39,7 +39,7 @@ function NavItem({ item }) {
       _active={{ color: 'gray.800', bg: 'gray.100', fontWeight: 'bold' }}
     >
       <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
-      <Text>{title}</Text>
+      <Typography>{title}</Typography>
       {info && info}
     </StyledNavItem>
   );

--- a/client/src/sections/@dashboard/app/AppNewsUpdate.js
+++ b/client/src/sections/@dashboard/app/AppNewsUpdate.js
@@ -1,5 +1,5 @@
-import { Button, Stack } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { Button } from '@chakra-ui/react';
+import { Box, Stack } from '@mui/material';
 // @mui
 import PropTypes from 'prop-types';
 // utils

--- a/client/src/sections/@dashboard/app/AppOrderTimeline.js
+++ b/client/src/sections/@dashboard/app/AppOrderTimeline.js
@@ -1,6 +1,13 @@
 import PropTypes from 'prop-types';
-import { Card, CardHeader, CardBody, Stack, Text, Circle } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Stack,
+  Typography,
+  Box,
+} from '@mui/material';
+import { blue, green, teal, orange, red, grey } from '@mui/material/colors';
 import { fDateTime } from '../../../utils/formatTime';
 
 AppOrderTimeline.propTypes = {
@@ -12,21 +19,19 @@ AppOrderTimeline.propTypes = {
 export default function AppOrderTimeline({ title, subheader, list, ...other }) {
   return (
     <Card {...other}>
-      <CardHeader>
-        <Text fontWeight="bold">{title}</Text>
-        {subheader && (
-          <Text fontSize="sm" color="gray.500">
-            {subheader}
-          </Text>
-        )}
-      </CardHeader>
-      <CardBody>
+      <CardHeader
+        title={title}
+        subheader={subheader}
+        titleTypographyProps={{ fontWeight: 'bold' }}
+        subheaderTypographyProps={{ color: 'text.secondary', variant: 'body2' }}
+      />
+      <CardContent>
         <Stack>
           {list.map((item, index) => (
             <OrderItem key={item.id} item={item} isLast={index === list.length - 1} />
           ))}
         </Stack>
-      </CardBody>
+      </CardContent>
     </Card>
   );
 }
@@ -34,23 +39,25 @@ export default function AppOrderTimeline({ title, subheader, list, ...other }) {
 function OrderItem({ item, isLast }) {
   const { type, title, time } = item;
   const color =
-    (type === 'order1' && 'blue.500') ||
-    (type === 'order2' && 'green.500') ||
-    (type === 'order3' && 'teal.500') ||
-    (type === 'order4' && 'orange.500') ||
-    'red.500';
+    (type === 'order1' && blue[500]) ||
+    (type === 'order2' && green[500]) ||
+    (type === 'order3' && teal[500]) ||
+    (type === 'order4' && orange[500]) ||
+    red[500];
 
   return (
     <Box display="flex" alignItems="flex-start">
       <Box mr={2} display="flex" flexDirection="column" alignItems="center">
-        <Circle size="8px" bg={color} mt={2} />
-        {!isLast && <Box flex="1" w="1px" bg="gray.200" />}
+        <Box
+          sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: color, mt: 1 }}
+        />
+        {!isLast && <Box sx={{ flex: 1, width: 1, bgcolor: grey[200] }} />}
       </Box>
       <Box>
-        <Text fontWeight="medium">{title}</Text>
-        <Text fontSize="sm" color="gray.500">
+        <Typography fontWeight="medium">{title}</Typography>
+        <Typography variant="body2" color="text.secondary">
           {fDateTime(time)}
-        </Text>
+        </Typography>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
- swap Chakra card elements for Material UI equivalents in `AppOrderTimeline`
- use MUI `Stack` rather than Chakra `Stack` in `AppNewsUpdate`
- replace Chakra `Text` with MUI `Typography` in admin nav components

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*