### PR TITLE
Swap Chakra menus for MUI

### DIFF
--- a/client/src/layouts/dashboard/header/AccountPopover.js
+++ b/client/src/layouts/dashboard/header/AccountPopover.js
@@ -1,17 +1,15 @@
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import {
   Avatar,
   Divider,
   IconButton,
   Menu,
-  MenuButton,
   MenuItem,
-  MenuList,
   Stack,
-  Text,
-  useDisclosure,
-} from '@chakra-ui/react';
-import { Box } from '@mui/material';
+  Typography,
+  Box,
+} from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import account from '../../../_mock/account';
 
@@ -30,38 +28,53 @@ MenuOption.propTypes = {
 
 export default function AccountPopover({ onLogout }) {
   const navigate = useNavigate();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
   const handleLogout = () => {
-    onClose();
+    handleClose();
     if (onLogout) onLogout();
     navigate('/login', { replace: true });
   };
 
   return (
-    <Menu isOpen={isOpen} onClose={onClose} placement="bottom-end">
-      <MenuButton as={IconButton} onClick={onOpen} p={0}>
+    <>
+      <IconButton onClick={handleOpen} sx={{ p: 0 }}>
         <Avatar src={account.photoURL} alt="account" />
-      </MenuButton>
-      <MenuList p={0} mt={1.5} ml={0.75} w="180px">
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        PaperProps={{ sx: { p: 0, mt: 1.5, ml: 0.75, width: 180 } }}
+      >
         <Box my={1.5} px={2.5}>
-          <Text fontWeight="semibold" noOfLines={1}>
+          <Typography variant="subtitle2" noWrap>
             {account.displayName}
-          </Text>
-          <Text fontSize="sm" color="gray.500" noOfLines={1}>
+          </Typography>
+          <Typography variant="body2" color="text.secondary" noWrap>
             {account.email}
-          </Text>
+          </Typography>
         </Box>
-        <Divider borderStyle="dashed" />
+        <Divider sx={{ borderStyle: 'dashed' }} />
         <Stack p={1}>
           <MenuOption label="Profile" onClick={() => navigate('/dashboard/app')} />
         </Stack>
-        <Divider borderStyle="dashed" />
-        <MenuItem onClick={handleLogout} m={1}>
+        <Divider sx={{ borderStyle: 'dashed' }} />
+        <MenuItem onClick={handleLogout} sx={{ m: 1 }}>
           Logout
         </MenuItem>
-      </MenuList>
-    </Menu>
+      </Menu>
+    </>
   );
 }
 

--- a/client/src/layouts/dashboard/header/LanguagePopover.js
+++ b/client/src/layouts/dashboard/header/LanguagePopover.js
@@ -1,14 +1,6 @@
-import {
-  IconButton,
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
-  Stack,
-  useDisclosure,
-} from '@chakra-ui/react';
-import { Box } from '@mui/material';
-import { transparentize } from '@chakra-ui/theme-tools';
+import { useState } from 'react';
+import { IconButton, Menu, MenuItem, Stack, Box } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 
 const LANGS = [
   {
@@ -24,30 +16,52 @@ const LANGS = [
 ];
 
 export default function LanguagePopover() {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleOpen = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
 
   return (
-    <Menu isOpen={isOpen} onClose={onClose} placement="bottom-end">
-      <MenuButton
-        as={IconButton}
-        onClick={onOpen}
-        p={0}
-        w="44px"
-        h="44px"
-        bg={isOpen ? (theme) => transparentize(theme.colors.primary[500], 0.12) : undefined}
+    <>
+      <IconButton
+        onClick={handleOpen}
+        sx={{
+          p: 0,
+          width: 44,
+          height: 44,
+          ...(open && { bgcolor: (theme) => alpha(theme.palette.primary.main, 0.12) }),
+        }}
       >
         <img src={LANGS[0].icon} alt={LANGS[0].label} />
-      </MenuButton>
-      <MenuList p={1} mt={1.5} ml={0.75} w="180px">
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        PaperProps={{ sx: { p: 1, mt: 1.5, ml: 0.75, width: 180 } }}
+      >
         <Stack spacing={0.75}>
           {LANGS.map((option) => (
-            <MenuItem key={option.value} onClick={onClose} isDisabled={option.value === LANGS[0].value}>
-              <Box as="img" alt={option.label} src={option.icon} w={28} mr={2} />
+            <MenuItem
+              key={option.value}
+              onClick={handleClose}
+              disabled={option.value === LANGS[0].value}
+            >
+              <Box component="img" alt={option.label} src={option.icon} sx={{ width: 28, mr: 2 }} />
               {option.label}
             </MenuItem>
           ))}
         </Stack>
-      </MenuList>
-    </Menu>
+      </Menu>
+    </>
   );
 }

--- a/client/src/layouts/dashboard/header/Searchbar.js
+++ b/client/src/layouts/dashboard/header/Searchbar.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { chakra, Input, IconButton, Slide, InputGroup, InputLeftElement, useOutsideClick } from '@chakra-ui/react';
 import { Box } from '@mui/material';
-import { transparentize } from '@chakra-ui/theme-tools';
+import { alpha } from '@mui/material/styles';
 import Iconify from '../../../components/iconify';
 
 const HEADER_MOBILE = 64;
@@ -18,7 +18,7 @@ const StyledSearchbar = chakra('div', {
     alignItems: 'center',
     height: `${HEADER_MOBILE}px`,
     px: 3,
-    bg: (theme) => transparentize(theme.colors.white, 0.2),
+    bg: (theme) => alpha(theme.palette.common.white, 0.2),
     backdropFilter: 'blur(6px)',
     boxShadow: 'md',
     '@media (min-width: 48em)': {

--- a/client/src/layouts/dashboard/nav/index.js
+++ b/client/src/layouts/dashboard/nav/index.js
@@ -12,7 +12,7 @@ import {
   chakra,
 } from '@chakra-ui/react';
 import { Box } from '@mui/material';
-import { transparentize } from '@chakra-ui/theme-tools';
+import { alpha } from '@mui/material/styles';
 import { useLocation } from 'react-router-dom';
 import useResponsive from '../../../hooks/useResponsive';
 import Scrollbar from '../../../components/scrollbar';
@@ -32,7 +32,7 @@ const StyledAccount = chakra('div', {
     alignItems: 'center',
     p: 2,
     borderRadius: 'md',
-    bg: (theme) => transparentize(theme.colors.gray[500], 0.12),
+    bg: (theme) => alpha(theme.palette.grey[500], 0.12),
   },
 });
 


### PR DESCRIPTION
## Summary
- replace Chakra popover menus with MUI Menu components
- use MUI's `alpha` helper instead of Chakra `transparentize`

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*