### PR TITLE
Replace Chakra components with MUI

### DIFF
--- a/client/src/components/admin-navsection/AdminNavSection.js
+++ b/client/src/components/admin-navsection/AdminNavSection.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { NavLink as RouterLink } from 'react-router-dom';
-import { List, Text } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { List } from '@chakra-ui/react';
+import { Box, Typography } from '@mui/material';
 import { StyledNavItem, StyledNavItemIcon } from '../nav-section/styles';
 import { useAppSelector } from '../../hooks/hooks';
 import { authSelector } from '../../redux/slice/authSlice';
@@ -37,7 +37,7 @@ function NavItem({ item }) {
       _active={{ color: 'gray.800', bg: 'gray.100', fontWeight: 'bold' }}
     >
       <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
-      <Text>{title}</Text>
+      <Typography>{title}</Typography>
       {info && info}
     </StyledNavItem>
   );

--- a/client/src/components/nav-section/NavSection.js
+++ b/client/src/components/nav-section/NavSection.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { NavLink as RouterLink } from 'react-router-dom';
-import { List, Text } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { List } from '@chakra-ui/react';
+import { Box, Typography } from '@mui/material';
 import { StyledNavItem, StyledNavItemIcon } from './styles';
 import { useAppSelector } from '../../hooks/hooks';
 import { authSelector } from '../../redux/slice/authSlice';
@@ -39,7 +39,7 @@ function NavItem({ item }) {
       _active={{ color: 'gray.800', bg: 'gray.100', fontWeight: 'bold' }}
     >
       <StyledNavItemIcon>{icon && icon}</StyledNavItemIcon>
-      <Text>{title}</Text>
+      <Typography>{title}</Typography>
       {info && info}
     </StyledNavItem>
   );

--- a/client/src/components/nav-section/styles.js
+++ b/client/src/components/nav-section/styles.js
@@ -1,26 +1,23 @@
-import { chakra } from '@chakra-ui/react';
+import { styled } from '@mui/material/styles';
 
-export const StyledNavItem = chakra('a', {
-  baseStyle: {
-    display: 'flex',
-    alignItems: 'center',
-    height: '48px',
-    position: 'relative',
-    textTransform: 'capitalize',
-    color: 'gray.600',
-    borderRadius: 'md',
-    px: 2,
-  },
-});
+export const StyledNavItem = styled('a')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  height: 48,
+  position: 'relative',
+  textTransform: 'capitalize',
+  color: theme.palette.grey[600],
+  borderRadius: theme.shape.borderRadius,
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+}));
 
-export const StyledNavItemIcon = chakra('div', {
-  baseStyle: {
-    width: '22px',
-    height: '22px',
-    color: 'inherit',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    mr: 2,
-  },
-});
+export const StyledNavItemIcon = styled('div')(({ theme }) => ({
+  width: 22,
+  height: 22,
+  color: 'inherit',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginRight: theme.spacing(2),
+}));

--- a/client/src/layouts/dashboard/header/AccountPopover.js
+++ b/client/src/layouts/dashboard/header/AccountPopover.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import {
-  Avatar,
   Divider,
   IconButton,
   Menu,
@@ -8,10 +7,9 @@ import {
   MenuItem,
   MenuList,
   Stack,
-  Text,
   useDisclosure,
 } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { Box, Avatar, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import account from '../../../_mock/account';
 
@@ -44,20 +42,20 @@ export default function AccountPopover({ onLogout }) {
         <Avatar src={account.photoURL} alt="account" />
       </MenuButton>
       <MenuList p={0} mt={1.5} ml={0.75} w="180px">
-        <Box my={1.5} px={2.5}>
-          <Text fontWeight="semibold" noOfLines={1}>
+        <Box sx={{ my: 1.5, px: 2.5 }}>
+          <Typography fontWeight="fontWeightSemibold" noWrap>
             {account.displayName}
-          </Text>
-          <Text fontSize="sm" color="gray.500" noOfLines={1}>
+          </Typography>
+          <Typography variant="body2" color="grey.500" noWrap>
             {account.email}
-          </Text>
+          </Typography>
         </Box>
         <Divider borderStyle="dashed" />
         <Stack p={1}>
           <MenuOption label="Profile" onClick={() => navigate('/dashboard/app')} />
         </Stack>
         <Divider borderStyle="dashed" />
-        <MenuItem onClick={handleLogout} m={1}>
+        <MenuItem onClick={handleLogout} sx={{ m: 1 }}>
           Logout
         </MenuItem>
       </MenuList>

--- a/client/src/layouts/dashboard/header/LanguagePopover.js
+++ b/client/src/layouts/dashboard/header/LanguagePopover.js
@@ -8,7 +8,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { Box } from '@mui/material';
-import { transparentize } from '@chakra-ui/theme-tools';
+import { alpha } from '@mui/material/styles';
 
 const LANGS = [
   {
@@ -34,7 +34,7 @@ export default function LanguagePopover() {
         p={0}
         w="44px"
         h="44px"
-        bg={isOpen ? (theme) => transparentize(theme.colors.primary[500], 0.12) : undefined}
+        bg={isOpen ? (theme) => alpha(theme.palette.primary.main, 0.12) : undefined}
       >
         <img src={LANGS[0].icon} alt={LANGS[0].label} />
       </MenuButton>

--- a/client/src/layouts/dashboard/header/NotificationsPopover.js
+++ b/client/src/layouts/dashboard/header/NotificationsPopover.js
@@ -7,7 +7,6 @@ import {
   PopoverContent,
   PopoverArrow,
   PopoverBody,
-  Text,
   List,
   ListItem,
   Divider,
@@ -15,7 +14,7 @@ import {
   Badge,
   useDisclosure,
 } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import Iconify from '../../../components/iconify';
 
 const mockNotifications = [...Array(3)].map(() => ({
@@ -50,12 +49,12 @@ export default function NotificationsPopover() {
       <PopoverContent mt={1.5} ml={0.75} w="360px">
         <PopoverArrow />
         <PopoverBody p={0}>
-          <Box display="flex" alignItems="center" py={2} px={2.5}>
+          <Box sx={{ display: 'flex', alignItems: 'center', py: 2, px: 2.5 }}>
             <Box sx={{ flexGrow: 1 }}>
-            <Text fontWeight="semibold">Notifications</Text>
-            <Text fontSize="sm" color="gray.500">
+            <Typography fontWeight="fontWeightSemibold">Notifications</Typography>
+            <Typography variant="body2" color="grey.500">
               You have {totalUnRead} unread messages
-            </Text>
+            </Typography>
           </Box>
           {totalUnRead > 0 && (
             <Tooltip label="Mark all as read">
@@ -70,10 +69,10 @@ export default function NotificationsPopover() {
           {notifications.map((notification) => (
             <ListItem key={notification.id} py={2} px={4} borderBottomWidth="1px">
               <Box>
-                <Text fontWeight="medium">{notification.title}</Text>
-                <Text fontSize="sm" color="gray.500">
+                <Typography fontWeight="fontWeightMedium">{notification.title}</Typography>
+                <Typography variant="body2" color="grey.500">
                   {notification.description}
-                </Text>
+                </Typography>
               </Box>
             </ListItem>
           ))}

--- a/client/src/layouts/dashboard/header/Searchbar.js
+++ b/client/src/layouts/dashboard/header/Searchbar.js
@@ -1,32 +1,32 @@
 import React, { useState } from 'react';
-import { chakra, Input, IconButton, Slide, InputGroup, InputLeftElement, useOutsideClick } from '@chakra-ui/react';
+import { Input, IconButton, Slide, InputGroup, InputLeftElement, useOutsideClick } from '@chakra-ui/react';
 import { Box } from '@mui/material';
-import { transparentize } from '@chakra-ui/theme-tools';
+import { styled, alpha } from '@mui/material/styles';
 import Iconify from '../../../components/iconify';
 
 const HEADER_MOBILE = 64;
 const HEADER_DESKTOP = 92;
 
-const StyledSearchbar = chakra('div', {
-  baseStyle: {
-    top: 0,
-    left: 0,
-    zIndex: 99,
-    width: '100%',
-    display: 'flex',
-    position: 'absolute',
-    alignItems: 'center',
-    height: `${HEADER_MOBILE}px`,
-    px: 3,
-    bg: (theme) => transparentize(theme.colors.white, 0.2),
-    backdropFilter: 'blur(6px)',
-    boxShadow: 'md',
-    '@media (min-width: 48em)': {
-      height: `${HEADER_DESKTOP}px`,
-      px: 5,
-    },
+const StyledSearchbar = styled('div')(({ theme }) => ({
+  top: 0,
+  left: 0,
+  zIndex: 99,
+  width: '100%',
+  display: 'flex',
+  position: 'absolute',
+  alignItems: 'center',
+  height: `${HEADER_MOBILE}px`,
+  paddingLeft: theme.spacing(1.5),
+  paddingRight: theme.spacing(1.5),
+  background: alpha(theme.palette.common.white, 0.2),
+  backdropFilter: 'blur(6px)',
+  boxShadow: theme.shadows[4],
+  [theme.breakpoints.up('md')]: {
+    height: `${HEADER_DESKTOP}px`,
+    paddingLeft: theme.spacing(2.5),
+    paddingRight: theme.spacing(2.5),
   },
-});
+}));
 
 export default function Searchbar() {
   const [open, setOpen] = useState(false);

--- a/client/src/layouts/dashboard/header/index.js
+++ b/client/src/layouts/dashboard/header/index.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { IconButton, Button, Flex, chakra } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { IconButton } from '@chakra-ui/react';
+import { Box, Button } from '@mui/material';
+import { styled } from '@mui/material/styles';
 import Iconify from '../../../components/iconify';
 import Searchbar from './Searchbar';
 import AccountPopover from './AccountPopover';
@@ -13,29 +14,28 @@ const NAV_WIDTH = 280;
 const HEADER_MOBILE = 64;
 const HEADER_DESKTOP = 92;
 
-const StyledRoot = chakra('header', {
-  baseStyle: {
-    position: 'sticky',
-    top: 0,
-    width: '100%',
-    boxShadow: 'none',
-    backdropFilter: 'blur(6px)',
-    bg: 'white',
-    zIndex: 'docked',
-  },
-});
+const StyledRoot = styled('header')(({ theme }) => ({
+  position: 'sticky',
+  top: 0,
+  width: '100%',
+  boxShadow: 'none',
+  backdropFilter: 'blur(6px)',
+  background: theme.palette.common.white,
+  zIndex: theme.zIndex.appBar,
+}));
 
-const StyledToolbar = chakra(Flex, {
-  baseStyle: {
-    minHeight: HEADER_MOBILE,
-    alignItems: 'center',
-    px: 4,
-    '@media (min-width: 62em)': {
-      minHeight: HEADER_DESKTOP,
-      px: 5,
-    },
+const StyledToolbar = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  minHeight: HEADER_MOBILE,
+  alignItems: 'center',
+  paddingLeft: theme.spacing(2),
+  paddingRight: theme.spacing(2),
+  [theme.breakpoints.up('lg')]: {
+    minHeight: HEADER_DESKTOP,
+    paddingLeft: theme.spacing(2.5),
+    paddingRight: theme.spacing(2.5),
   },
-});
+}));
 
 Header.propTypes = {
   onOpenNav: PropTypes.func,

--- a/client/src/layouts/dashboard/nav/index.js
+++ b/client/src/layouts/dashboard/nav/index.js
@@ -1,18 +1,7 @@
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
-import {
-  Drawer,
-  DrawerOverlay,
-  DrawerContent,
-  DrawerBody,
-  Avatar,
-  Text,
-  Link,
-  Button,
-  chakra,
-} from '@chakra-ui/react';
-import { Box } from '@mui/material';
-import { transparentize } from '@chakra-ui/theme-tools';
+import { Box, Drawer, Avatar, Typography, Link, Button } from '@mui/material';
+import { styled, alpha } from '@mui/material/styles';
 import { useLocation } from 'react-router-dom';
 import useResponsive from '../../../hooks/useResponsive';
 import Scrollbar from '../../../components/scrollbar';
@@ -26,15 +15,13 @@ import account from '../../../_mock/account';
 
 const NAV_WIDTH = 280;
 
-const StyledAccount = chakra('div', {
-  baseStyle: {
-    display: 'flex',
-    alignItems: 'center',
-    p: 2,
-    borderRadius: 'md',
-    bg: (theme) => transparentize(theme.colors.gray[500], 0.12),
-  },
-});
+const StyledAccount = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  padding: theme.spacing(2),
+  borderRadius: theme.shape.borderRadius,
+  background: alpha(theme.palette.grey[500], 0.12),
+}));
 
 Nav.propTypes = {
   openNav: PropTypes.bool,
@@ -60,32 +47,32 @@ export default function Nav({ openNav, onCloseNav }) {
         '& .simplebar-content': { height: 1, display: 'flex', flexDirection: 'column' },
       }}
     >
-      <Box px={2.5} py={3} display="flex" justifyContent="flex-start" alignItems="center">
+      <Box sx={{ px: 2.5, py: 3, display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }}>
         <img
           src={`${process.env.PUBLIC_URL}/assets/images/iconImages/logo.png`}
           alt="Voltaic CRM Logo"
           style={{ maxWidth: '150px', maxHeight: '150px', width: 'auto', height: 'auto', objectFit: 'contain' }}
         />
       </Box>
-      <Box mb={5} mx={2.5}>
-        <Link textDecoration="none">
+      <Box sx={{ mb: 5, mx: 2.5 }}>
+        <Link underline="none">
           <StyledAccount>
             <Avatar src={account.photoURL} alt="photoURL" />
-            <Box ml={2}>
-              <Text fontWeight="semibold" color="gray.800">
+            <Box sx={{ ml: 2 }}>
+              <Typography fontWeight="fontWeightSemibold" color="grey.800">
                 {account.displayName}
-              </Text>
-              <Text fontSize="sm" color="gray.500">
+              </Typography>
+              <Typography variant="body2" color="grey.500">
                 {account.role}
-              </Text>
+              </Typography>
             </Box>
           </StyledAccount>
         </Link>
       </Box>
       {data.role === 'Mentor' ? <AdminNavSection data={AdminConfig} /> : <NavSection data={navConfig} />}
-      <Box flexGrow={1} />
-      <Box px={2.5} pb={3} mt={10}>
-        <Button href="/login" colorScheme="blue">
+      <Box sx={{ flexGrow: 1 }} />
+      <Box sx={{ px: 2.5, pb: 3, mt: 10 }}>
+        <Button href="/login" variant="contained" color="primary">
           Log out
         </Button>
       </Box>
@@ -93,17 +80,14 @@ export default function Nav({ openNav, onCloseNav }) {
   );
 
   return (
-    <Box as="nav" flexShrink={{ lg: 0 }} w={{ lg: NAV_WIDTH }}>
+    <Box component="nav" sx={{ flexShrink: { lg: 0 }, width: { lg: NAV_WIDTH } }}>
       {isDesktop ? (
-        <Box w={NAV_WIDTH} bg="gray.50" borderRight="1px dashed" borderColor="gray.200">
+        <Box sx={{ width: NAV_WIDTH, bgcolor: 'grey.50', borderRight: '1px dashed', borderColor: 'grey.200' }}>
           {renderContent}
         </Box>
       ) : (
-        <Drawer isOpen={openNav} onClose={onCloseNav} placement="left">
-          <DrawerOverlay />
-          <DrawerContent w={NAV_WIDTH}>
-            <DrawerBody p={0}>{renderContent}</DrawerBody>
-          </DrawerContent>
+        <Drawer anchor="left" open={openNav} onClose={onCloseNav} PaperProps={{ sx: { width: NAV_WIDTH } }}>
+          {renderContent}
         </Drawer>
       )}
     </Box>

--- a/client/src/sections/@dashboard/app/AppNewsUpdate.js
+++ b/client/src/sections/@dashboard/app/AppNewsUpdate.js
@@ -1,5 +1,5 @@
-import { Button, Stack } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { Stack } from '@chakra-ui/react';
+import { Box, Button } from '@mui/material';
 // @mui
 import PropTypes from 'prop-types';
 // utils

--- a/client/src/sections/@dashboard/app/AppOrderTimeline.js
+++ b/client/src/sections/@dashboard/app/AppOrderTimeline.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import { Card, CardHeader, CardBody, Stack, Text, Circle } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { Card, CardHeader, CardBody, Stack, Circle } from '@chakra-ui/react';
+import { Box, Typography } from '@mui/material';
 import { fDateTime } from '../../../utils/formatTime';
 
 AppOrderTimeline.propTypes = {
@@ -13,11 +13,11 @@ export default function AppOrderTimeline({ title, subheader, list, ...other }) {
   return (
     <Card {...other}>
       <CardHeader>
-        <Text fontWeight="bold">{title}</Text>
+        <Typography fontWeight="fontWeightBold">{title}</Typography>
         {subheader && (
-          <Text fontSize="sm" color="gray.500">
+          <Typography variant="body2" color="grey.500">
             {subheader}
-          </Text>
+          </Typography>
         )}
       </CardHeader>
       <CardBody>
@@ -41,16 +41,16 @@ function OrderItem({ item, isLast }) {
     'red.500';
 
   return (
-    <Box display="flex" alignItems="flex-start">
-      <Box mr={2} display="flex" flexDirection="column" alignItems="center">
+    <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+      <Box sx={{ mr: 2, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
         <Circle size="8px" bg={color} mt={2} />
-        {!isLast && <Box flex="1" w="1px" bg="gray.200" />}
+        {!isLast && <Box sx={{ flex: 1, width: '1px', bgcolor: 'gray.200' }} />}
       </Box>
       <Box>
-        <Text fontWeight="medium">{title}</Text>
-        <Text fontSize="sm" color="gray.500">
+        <Typography fontWeight="fontWeightMedium">{title}</Typography>
+        <Typography variant="body2" color="grey.500">
           {fDateTime(time)}
-        </Text>
+        </Typography>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary
- swap Chakra Drawer, Avatar, Text, Link, Button with Material UI equivalents
- reimplement chakra styled components using MUI `styled`
- use `alpha` instead of `transparentize` for colors

## Testing
- `npm test` *(fails: react-scripts not found)*