### PR TITLE
Switch Chakra components to MUI

### DIFF
--- a/client/src/layouts/dashboard/header/AccountPopover.js
+++ b/client/src/layouts/dashboard/header/AccountPopover.js
@@ -1,17 +1,15 @@
 import PropTypes from 'prop-types';
 import {
   Avatar,
-  Divider,
   IconButton,
   Menu,
   MenuButton,
   MenuItem,
   MenuList,
-  Stack,
   Text,
   useDisclosure,
 } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { Box, Divider, Stack } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import account from '../../../_mock/account';
 

--- a/client/src/layouts/dashboard/header/LanguagePopover.js
+++ b/client/src/layouts/dashboard/header/LanguagePopover.js
@@ -4,10 +4,9 @@ import {
   MenuButton,
   MenuList,
   MenuItem,
-  Stack,
   useDisclosure,
 } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import { transparentize } from '@chakra-ui/theme-tools';
 
 const LANGS = [

--- a/client/src/layouts/dashboard/header/NotificationsPopover.js
+++ b/client/src/layouts/dashboard/header/NotificationsPopover.js
@@ -10,12 +10,11 @@ import {
   Text,
   List,
   ListItem,
-  Divider,
   Tooltip,
   Badge,
   useDisclosure,
 } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { Box, Divider } from '@mui/material';
 import Iconify from '../../../components/iconify';
 
 const mockNotifications = [...Array(3)].map(() => ({

--- a/client/src/layouts/dashboard/header/index.js
+++ b/client/src/layouts/dashboard/header/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import { IconButton, Button, Flex, chakra } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { IconButton, Flex, chakra } from '@chakra-ui/react';
+import { Box, Button } from '@mui/material';
 import Iconify from '../../../components/iconify';
 import Searchbar from './Searchbar';
 import AccountPopover from './AccountPopover';

--- a/client/src/sections/@dashboard/app/AppNewsUpdate.js
+++ b/client/src/sections/@dashboard/app/AppNewsUpdate.js
@@ -1,7 +1,14 @@
-import { Button, Stack } from '@chakra-ui/react';
-import { Box } from '@mui/material';
-// @mui
 import PropTypes from 'prop-types';
+import {
+  Box,
+  Button,
+  Card,
+  CardHeader,
+  Divider,
+  Link,
+  Stack,
+  Typography,
+} from '@mui/material';
 // utils
 import { fToNow } from '../../../utils/formatTime';
 // components

--- a/client/src/sections/@dashboard/app/AppOrderTimeline.js
+++ b/client/src/sections/@dashboard/app/AppOrderTimeline.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-import { Card, CardHeader, CardBody, Stack, Text, Circle } from '@chakra-ui/react';
-import { Box } from '@mui/material';
+import { CardBody, Text, Circle } from '@chakra-ui/react';
+import { Box, Card, CardHeader, Stack } from '@mui/material';
 import { fDateTime } from '../../../utils/formatTime';
 
 AppOrderTimeline.propTypes = {


### PR DESCRIPTION
## Summary
- replace Chakra Button & Stack with MUI equivalents
- import Card, CardHeader, Divider, Link and Typography from `@mui/material`

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*