### PR TITLE
Remove duplicate StyledNavItemIcon

### DIFF
--- a/client/src/components/nav-section/styles.js
+++ b/client/src/components/nav-section/styles.js
@@ -19,16 +19,6 @@ export const StyledNavItem = styled(Box)(({ theme }) => ({
 
 export const StyledNavItemIcon = styled('div')(({ theme }) => ({
 
-  width: '22px',
-  height: '22px',
-
-  paddingLeft: theme.spacing(1),
-  paddingRight: theme.spacing(1),
-  textDecoration: 'none',
-}));
-
-export const StyledNavItemIcon = styled('div')(({ theme }) => ({
-
   width: 22,
   height: 22,
   color: 'inherit',


### PR DESCRIPTION
## Summary
- remove duplicated `StyledNavItemIcon` style definition

## Testing
- `npm test` *(fails: `react-scripts` not found)*