### PR TITLE
Refactor AccountPopover to Material UI

### DIFF
--- a/client/src/layouts/dashboard/header/AccountPopover.js
+++ b/client/src/layouts/dashboard/header/AccountPopover.js
@@ -1,14 +1,15 @@
 import PropTypes from 'prop-types';
 import { useState } from 'react';
 import {
-
+  Avatar,
   Divider,
   IconButton,
+  Menu,
+  MenuItem,
   Stack,
-  useDisclosure,
-} from '@chakra-ui/react';
-
-import { Box, Typography } from '@mui/material';
+  Box,
+  Typography,
+} from '@mui/material';
 
 
 
@@ -47,16 +48,11 @@ export default function AccountPopover({ onLogout }) {
     navigate('/login', { replace: true });
   };
 
-  const open = Boolean(anchorEl);
 
   return (
     <>
-
-
-      <IconButton onClick={handleOpen} p={0}>
-
+      <IconButton onClick={handleOpen} sx={{ p: 0 }}>
         <Avatar src={account.photoURL} alt="account" />
-
       </IconButton>
       <Menu
         anchorEl={anchorEl}
@@ -83,7 +79,7 @@ export default function AccountPopover({ onLogout }) {
           </Typography>
         </Box>
         <Divider sx={{ borderStyle: 'dashed' }} />
-        <Stack p={1}>
+        <Stack sx={{ p: 1 }}>
           <MenuOption label="Profile" onClick={() => {
             handleClose();
             navigate('/dashboard/app');


### PR DESCRIPTION
## Summary
- migrate AccountPopover component to Material‑UI imports
- remove unused Chakra hook and adjust component props

## Testing
- `npm test` *(fails: react-scripts not found)*