### PR TITLE
Fix MUI imports for AppTrafficBySite

### DIFF
--- a/client/src/sections/@dashboard/app/AppTrafficBySite.js
+++ b/client/src/sections/@dashboard/app/AppTrafficBySite.js
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Card, CardHeader, CardContent, Paper, Typography } from '@mui/material';
 // @mui
 import PropTypes from 'prop-types';
 // utils


### PR DESCRIPTION
## Summary
- import Card-related MUI components in AppTrafficBySite

## Testing
- `npm test` *(fails: react-scripts not found)*