### PR TITLE
Fix imports in AppWebsiteVisits

### DIFF
--- a/client/src/sections/@dashboard/app/AppWebsiteVisits.js
+++ b/client/src/sections/@dashboard/app/AppWebsiteVisits.js
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { Box, Card, CardHeader } from '@mui/material';
 import PropTypes from 'prop-types';
 import ReactApexChart from 'react-apexcharts';
 // @mui


### PR DESCRIPTION
## Summary
- include `Card` and `CardHeader` imports in `AppWebsiteVisits`

## Testing
- `npm test --workspaces` *(fails: `react-scripts: not found`)*