### PR TITLE
Replace Babel plugin proposal with transform

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -97,7 +97,7 @@
   "devDependencies": {
     "@babel/core": "^7.19.3",
     "@babel/eslint-parser": "^7.19.1",
-    "@babel/plugin-proposal-private-property-in-object": "^7.21.0",
+    "@babel/plugin-transform-private-property-in-object": "^7.21.0",
     "@svgr/webpack": "^6.5.0",
     "eslint": "^8.25.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -353,9 +353,9 @@
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
+"@babel/plugin-transform-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
   version "7.21.0-placeholder-for-preset-env.2"
-  resolved "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
@@ -989,7 +989,7 @@
     "@babel/helper-validator-option" "^7.22.15"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.22.15"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.22.15"
-    "@babel/plugin-proposal-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
+    "@babel/plugin-transform-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
     "@babel/plugin-syntax-async-generators" "^7.8.4"
     "@babel/plugin-syntax-class-properties" "^7.12.13"
     "@babel/plugin-syntax-class-static-block" "^7.14.5"


### PR DESCRIPTION
## Summary
- swap out Babel proposal plugin in favor of the transform variant
- update lockfile to match

## Testing
- `yarn install --immutable --mode=skip-build` *(fails: tunneling socket could not be established)*
- `npm run build` in `client` *(fails: react-scripts not found)*
