### PR TITLE
Fix nav imports and admin section logic

### DIFF
--- a/client/src/layouts/dashboard/nav/index.js
+++ b/client/src/layouts/dashboard/nav/index.js
@@ -17,10 +17,8 @@ import useResponsive from '../../../hooks/useResponsive';
 import Logo from '../../../components/logo';
 import Scrollbar from '../../../components/scrollbar';
 import NavSection from '../../../components/nav-section';
-//import AdminNavSection from'../../../components/admin-navsection';
-//import AdminConfig from './AdminConfig';
-import navConfig from './config';
 import { AdminNavSection } from '../../../components/admin-navsection/AdminNavSection';
+import navConfig from './config';
 import AdminConfig from './AdminConfig';
 
 
@@ -98,7 +96,11 @@ export default function Nav({ openNav, onCloseNav }) {
 
 
 {/* {data.recordID == "1890" ?  <AdminNavSection data={AdminConfig} /> : <NavSection data={navConfig} />} */}
-{data.role == "Mentor" ? <AdminNavSection data={AdminConfig}  /> : <NavSection data={navConfig} />}
+{data.role === 'Mentor' ? (
+  <AdminNavSection data={AdminConfig} />
+) : (
+  <NavSection data={navConfig} />
+)}
 
 
 


### PR DESCRIPTION
## Summary
- clean up imports for dashboard nav
- show `AdminNavSection` when the user role is Mentor using strict equality

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*