### PR TITLE
Remove forgotPassword from auth slice

### DIFF
--- a/client/src/redux/slice/authSlice.ts
+++ b/client/src/redux/slice/authSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { AdminResponseTypes } from '../../types';
 
-import { login, startVerification, register, verifyCode, completeVerification, forgotPassword, logout } from '../middleware/authentication';
+import { login, register, startVerification, verifyCode, completeVerification, logout } from '../middleware/authentication';
 
 type AuthState = {
   loading: boolean;
@@ -112,19 +112,6 @@ const authSlice = createSlice({
       state.isStartVerification = false;
     });
     builder.addCase(completeVerification.rejected, (state, action) => {
-      state.loading = false;
-      state.error = action.error.message;
-    });
-
-    // forgot password
-    builder.addCase(forgotPassword.pending, (state) => {
-      state.loading = true;
-    });
-    builder.addCase(forgotPassword.fulfilled, (state, action) => {
-      state.loading = false;
-      state.data = action.payload;
-    });
-    builder.addCase(forgotPassword.rejected, (state, action) => {
       state.loading = false;
       state.error = action.error.message;
     });


### PR DESCRIPTION
## Summary
- update auth slice imports
- remove leftover forgotPassword reducers

## Testing
- `npm test` *(fails: react-scripts not found)*