### PR TITLE
Remove unused forgotPassword

### DIFF
--- a/client/src/redux/slice/authSlice.ts
+++ b/client/src/redux/slice/authSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { AdminResponseTypes } from '../../types';
 
-import { login, startVerification, register, verifyCode, completeVerification, forgotPassword, logout } from '../middleware/authentication';
+import { login, startVerification, register, verifyCode, completeVerification, logout } from '../middleware/authentication';
 
 type AuthState = {
   loading: boolean;
@@ -115,20 +115,6 @@ const authSlice = createSlice({
       state.loading = false;
       state.error = action.error.message;
     });
-
-    // forgot password
-    builder.addCase(forgotPassword.pending, (state) => {
-      state.loading = true;
-    });
-    builder.addCase(forgotPassword.fulfilled, (state, action) => {
-      state.loading = false;
-      state.data = action.payload;
-    });
-    builder.addCase(forgotPassword.rejected, (state, action) => {
-      state.loading = false;
-      state.error = action.error.message;
-    });
-
     // logout
     builder.addCase(logout.pending, (state) => {
       state.loading = true;


### PR DESCRIPTION
## Summary
- clean up `authSlice` by dropping forgotten `forgotPassword` references

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*