### PR TITLE
Fix server startup and add missing services

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "version": "1.6.0",
   "private": false,
   "scripts": {
+    "dev": "react-scripts start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/server/src/services/RoleService.ts
+++ b/server/src/services/RoleService.ts
@@ -1,0 +1,20 @@
+import { Inject, Injectable } from "@tsed/di";
+import { MongooseModel } from "@tsed/mongoose";
+import { RoleModel } from "../models/RoleModel";
+
+@Injectable()
+export class RoleService {
+  constructor(@Inject(RoleModel) private roleModel: MongooseModel<RoleModel>) {}
+
+  public async findRoles() {
+    return await this.roleModel.find();
+  }
+
+  public async createRole(data: { name: string }) {
+    return await this.roleModel.create({ name: data.name });
+  }
+
+  public async updateRole(data: { _id: string; name: string }) {
+    return await this.roleModel.findByIdAndUpdate(data._id, { name: data.name });
+  }
+}

--- a/server/src/services/SaleRepService.ts
+++ b/server/src/services/SaleRepService.ts
@@ -1,0 +1,24 @@
+import { Inject, Injectable } from "@tsed/di";
+import { MongooseModel } from "@tsed/mongoose";
+import { SaleRepModel } from "../models/SaleRepModel";
+
+@Injectable()
+export class SaleRepService {
+  constructor(@Inject(SaleRepModel) private saleRepModel: MongooseModel<SaleRepModel>) {}
+
+  public async createSaleRep(data: { adminId: string }) {
+    return await this.saleRepModel.create({ adminId: data.adminId });
+  }
+
+  public async findSaleReps(query: any = {}) {
+    return await this.saleRepModel.find(query);
+  }
+
+  public async findSaleRepById(id: string) {
+    return await this.saleRepModel.findById(id);
+  }
+
+  public async updateSaleRep(id: string, update: Partial<SaleRepModel>) {
+    return await this.saleRepModel.findByIdAndUpdate(id, update);
+  }
+}


### PR DESCRIPTION
## Summary
- enable `npm run client` by adding dev script to client
- implement `RoleService` for role management
- implement `SaleRepService` used by admin services

## Testing
- `npm test` *(fails: package not present in lockfile, react-scripts not found)*