### PR TITLE
Add landing page for unauthenticated users

### DIFF
--- a/client/src/pages/LandingPage.tsx
+++ b/client/src/pages/LandingPage.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import { Link } from 'react-router-dom';
+import Logo from '../components/logo';
+
+const LandingPage = () => {
+  return (
+    <Box display="flex" flexDirection="column" minHeight="100vh">
+      <Box
+        component="header"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: 3,
+          py: 2,
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+        }}
+      >
+        <Logo />
+        <Box>
+          <Button component={Link} to="/login" color="inherit" sx={{ mr: 2 }}>
+            Login
+          </Button>
+          <Button component={Link} to="/register" variant="contained">
+            Register
+          </Button>
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          textAlign: 'center',
+          px: 3,
+        }}
+      >
+        <Typography variant="h3" gutterBottom>
+          Welcome to Voltaic CRM
+        </Typography>
+        <Typography variant="h6" color="text.secondary" sx={{ maxWidth: 600, mb: 4 }}>
+          Streamline your solar sales workflow and manage leads all in one place.
+        </Typography>
+        <Box>
+          <Button component={Link} to="/register" variant="contained" size="large" sx={{ mr: 2 }}>
+            Get Started
+          </Button>
+          <Button component={Link} to="/login" variant="outlined" size="large">
+            Login
+          </Button>
+        </Box>
+      </Box>
+
+      <Box
+        component="footer"
+        sx={{
+          textAlign: 'center',
+          py: 2,
+          borderTop: '1px solid',
+          borderColor: 'divider',
+        }}
+      >
+        <Typography variant="body2">&copy; {new Date().getFullYear()} Voltaic CRM</Typography>
+      </Box>
+    </Box>
+  );
+};
+
+export default LandingPage;

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -6,6 +6,7 @@ import LoginPage from './pages/LoginPage';
 import Page404 from './pages/Page404';
 import DealsPage from './pages/DealsPage';
 import LeadDetailPage from './pages/LeadDetailPage';
+import LandingPage from './pages/LandingPage';
 
 import RegisterPage from './pages/RegisterPage';
 
@@ -14,6 +15,10 @@ export default function Router() {
   let session = document.cookie.split(';').find((item) => item.includes('session'));
   session = session ? session.split('=')[1] : null;
   const routes = useRoutes([
+    {
+      path: '/',
+      element: session ? <Navigate to="/dashboard/deals" replace /> : <LandingPage />,
+    },
     {
       path: '/dashboard',
       element: session ? <DashboardLayout /> : <Navigate to="/login" replace />,
@@ -34,7 +39,7 @@ export default function Router() {
     {
       element: <SimpleLayout />,
       children: [
-        { element: <Navigate to="/login" />, index: true },
+        { element: <Navigate to="/" />, index: true },
         { path: '404', element: <Page404 /> },
         { path: '*', element: <Navigate to="/404" /> }
       ]


### PR DESCRIPTION
## Summary
- add a new marketing-focused `LandingPage`
- route `/` to the landing page and adjust SimpleLayout redirect
- send authenticated users straight to the dashboard

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*