### PR TITLE
Add tests for AccountsPayable and DealsData

### DIFF
--- a/tests/client/components/dataGrid/DealsData.test.tsx
+++ b/tests/client/components/dataGrid/DealsData.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import DealsData from '../../../../client/src/components/dataGrid/DealsData';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+describe('DealsData component', () => {
+  it('navigates to lead detail on click', async () => {
+    const navigate = jest.fn();
+    (require('react-router-dom') as any).useNavigate.mockReturnValue(navigate);
+    render(
+      <MemoryRouter>
+        <DealsData recordUserId={1} />
+      </MemoryRouter>
+    );
+
+    const button = await screen.findByRole('button', { name: /details/i });
+    fireEvent.click(button);
+    expect(navigate).toHaveBeenCalledWith('/dashboard/lead/1');
+  });
+});

--- a/tests/client/pages/accounts-payable/AccountsPayable.test.tsx
+++ b/tests/client/pages/accounts-payable/AccountsPayable.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import AccountsPayable from '../../../../client/src/pages/AccountsPayable';
+
+describe('AccountsPayable page', () => {
+  it('renders heading and placeholder row', () => {
+    render(<AccountsPayable />);
+    expect(
+      screen.getByRole('heading', { name: /accounts payable/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/no data/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- test AccountsPayable page rendering
- test DealsData navigation behavior

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*