### PR TITLE
Add calendar page with event management

### DIFF
--- a/client/src/layouts/dashboard/nav/config.js
+++ b/client/src/layouts/dashboard/nav/config.js
@@ -17,6 +17,11 @@ const navConfig = [
     icon: icon('ic_user')
   },
   {
+    title: 'Calendar',
+    path: '/dashboard/calendar',
+    icon: icon('ic_blog')
+  },
+  {
     title: 'Admin',
     path: '/dashboard/user',
     icon: icon('ic_lock'),

--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -6,6 +6,7 @@ import LoginPage from './pages/LoginPage';
 import Page404 from './pages/Page404';
 import DealsPage from './pages/DealsPage';
 import LeadDetailPage from './pages/LeadDetailPage';
+import CalendarPage from './pages/CalendarPage';
 
 import RegisterPage from './pages/RegisterPage';
 
@@ -22,6 +23,7 @@ export default function Router() {
         { path: 'deals', element: <DealsPage /> },
 
         { path: 'deals/:id', element: <LeadDetailPage /> },
+        { path: 'calendar', element: <CalendarPage /> },
         { path: 'user', element: <UserPage /> }
 
       ]


### PR DESCRIPTION
## Summary
- create `CalendarPage` and support create/edit/delete dialogs
- route `/dashboard/calendar`
- link "Calendar" in nav sidebar

## Testing
- `npm test --silent` *(fails: react-scripts not found)*