### PR TITLE
Add color mode support

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,13 +3,24 @@ import Router from './routes';
 import ThemeProvider from './theme';
 import ScrollToTop from './components/scroll-to-top';
 import { Alerts } from './components/alert/Alert';
+import { ColorModeProvider, useColorMode } from './theme/colorMode';
 
-export default function App() {
+function AppContent() {
+  const { mode } = useColorMode();
+
   return (
-    <ThemeProvider>
+    <ThemeProvider mode={mode}>
       <Alerts />
       <ScrollToTop />
       <Router />
     </ThemeProvider>
+  );
+}
+
+export default function App() {
+  return (
+    <ColorModeProvider>
+      <AppContent />
+    </ColorModeProvider>
   );
 }

--- a/client/src/theme/colorMode.tsx
+++ b/client/src/theme/colorMode.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+
+export type ColorMode = 'light' | 'dark';
+
+interface ColorModeContextValue {
+  mode: ColorMode;
+  toggleColorMode: () => void;
+}
+
+const ColorModeContext = createContext<ColorModeContextValue | undefined>(undefined);
+
+export const ColorModeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [mode, setMode] = useState<ColorMode>('light');
+
+  const toggleColorMode = () => {
+    setMode((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  const value = useMemo(() => ({ mode, toggleColorMode }), [mode]);
+
+  return <ColorModeContext.Provider value={value}>{children}</ColorModeContext.Provider>;
+};
+
+export const useColorMode = () => {
+  const context = useContext(ColorModeContext);
+  if (!context) {
+    throw new Error('useColorMode must be used within a ColorModeProvider');
+  }
+  return context;
+};

--- a/client/src/theme/index.tsx
+++ b/client/src/theme/index.tsx
@@ -2,32 +2,29 @@ import React from "react";
 import { useMemo } from "react";
 import { CssBaseline } from "@mui/material";
 import { ThemeProvider as MUIThemeProvider, createTheme, StyledEngineProvider } from "@mui/material/styles";
-import palette from "./palette";
+import { getPalette } from "./palette";
 import shadows from "./shadows";
 import typography from "./typography";
 import GlobalStyles from "./globalStyles";
 import customShadows from "./customShadows";
 import componentsOverride from "./overrides";
 
-export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+export default function ThemeProvider({
+  children,
+  mode = 'light',
+}: {
+  children: React.ReactNode;
+  mode?: 'light' | 'dark';
+}) {
   const themeOptions = useMemo(
     () => ({
-      palette: {
-        primary: {
-          main: '#556cd6',
-          contrastText: '#ffffff',
-        },
-        secondary: {
-          main: '#19857b',
-          contrastText: '#000000',
-        },
-      },
+      palette: getPalette(mode),
       shape: { borderRadius: 6 },
       typography,
       shadows: shadows(),
-      customShadows: customShadows()
+      customShadows: customShadows(),
     }),
-    []
+    [mode]
   );
 
   const theme = createTheme(themeOptions as any );

--- a/client/src/theme/palette.js
+++ b/client/src/theme/palette.js
@@ -70,6 +70,7 @@ const ERROR = {
   contrastText: '#fff',
 };
 
+// Base color tokens used across both light and dark modes
 const palette = {
   common: { black: '#000', white: '#fff' },
   primary: PRIMARY,
@@ -79,6 +80,11 @@ const palette = {
   warning: WARNING,
   error: ERROR,
   grey: GREY,
+};
+
+export const lightPalette = {
+  mode: 'light',
+  ...palette,
   divider: alpha(GREY[500], 0.24),
   text: {
     primary: GREY[800],
@@ -101,5 +107,33 @@ const palette = {
     disabledOpacity: 0.48,
   },
 };
+
+export const darkPalette = {
+  mode: 'dark',
+  ...palette,
+  divider: alpha(GREY[500], 0.24),
+  text: {
+    primary: '#fff',
+    secondary: GREY[500],
+    disabled: GREY[600],
+  },
+  background: {
+    paper: GREY[800],
+    default: GREY[900],
+    neutral: GREY[800],
+  },
+  action: {
+    active: GREY[500],
+    hover: alpha(GREY[500], 0.08),
+    selected: alpha(GREY[500], 0.16),
+    disabled: alpha(GREY[500], 0.8),
+    disabledBackground: alpha(GREY[500], 0.24),
+    focus: alpha(GREY[500], 0.24),
+    hoverOpacity: 0.08,
+    disabledOpacity: 0.48,
+  },
+};
+
+export const getPalette = (mode) => (mode === 'dark' ? darkPalette : lightPalette);
 
 export default palette;


### PR DESCRIPTION
## Summary
- allow ThemeProvider to receive `light` or `dark` mode
- define light and dark palettes
- provide a ColorMode context and hook
- wrap ThemeProvider with ColorModeProvider

## Testing
- `npm test --workspaces --silent` *(fails: react-scripts not found)*