### PR TITLE
Centralize grid styles and use skeleton loaders

### DIFF
--- a/client/src/components/dataGrid/ActiveRates.jsx
+++ b/client/src/components/dataGrid/ActiveRates.jsx
@@ -1,6 +1,6 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -22,12 +22,6 @@ export default function ActiveRates(props) {
   const { recordUserId } = props;
 
   // Grid style
-  const gridStyles = {
-    height: 350,
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto' // allow scrolling within the grid if content exceeds its bounds
-  };
-
   const [gridRef] = useState({});
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -123,7 +117,7 @@ export default function ActiveRates(props) {
       },
       {
         field: 'id',
-        headerName: 'id',
+        headerName: 'ID',
         width: 500,
         editable: false,
         hide: true
@@ -253,9 +247,7 @@ export default function ActiveRates(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
               pageSize={pageSize}
@@ -264,7 +256,7 @@ export default function ActiveRates(props) {
               paginationMode="server"
               onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
               onPageChange={(newPage) => setPage(newPage)}
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: 350 }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               rows={leadsRows}
               editable

--- a/client/src/components/dataGrid/DealsData.jsx
+++ b/client/src/components/dataGrid/DealsData.jsx
@@ -1,7 +1,7 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
 
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 
 import { useMemo, useState, useEffect } from 'react';
 import Box from '@mui/material/Box';
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { DataGridPro, GridToolbar } from '@mui/x-data-grid-pro';
 import { styled, darken, lighten } from '@mui/material/styles';
 import { baseURL } from '../../libs/client/apiClient';
-// import { gridStyles } from '../../constants/styles';
+import { gridStyles } from '../../constants/styles';
 
 export default function DealsData(props) {
 
@@ -52,20 +52,13 @@ export default function DealsData(props) {
 
   //STYLES:
 
-  const gridStyles = {
-    height: '75vh',
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto', // allow scrolling within the grid if content exceeds its bounds
-    backgroundColor: 'none'
-  };
-
   const apiRef = React.useRef(null);
 
   //CHANGE THE COLUMNS AND THOSE FIELDS THAT ARE ADDED TO IT.
   const columns = useMemo(
     () => [
       {
-        field: 'Profile',
+        field: 'profile',
         headerName: 'Profile',
         width: 150,
         editable: true,
@@ -154,14 +147,14 @@ export default function DealsData(props) {
 
       {
         field: 'ppwFinal',
-        headerName: 'PpwFinal',
+        headerName: 'PPW Final',
         width: 500,
         editable: false,
         hide: false
       },
       {
         field: 'repName',
-        headerName: 'repName',
+        headerName: 'Rep Name',
         width: 500,
         editable: false,
         hide: false
@@ -405,12 +398,10 @@ export default function DealsData(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: '75vh', backgroundColor: 'none' }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               //    rows={leadsRows}
               rows={filteredRows}

--- a/client/src/components/dataGrid/DealsDataLeadgen.jsx
+++ b/client/src/components/dataGrid/DealsDataLeadgen.jsx
@@ -1,6 +1,6 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 
 import { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { DataGridPro, GridToolbar } from '@mui/x-data-grid-pro';
 import { styled, darken, lighten } from '@mui/material/styles';
 import { baseURL } from '../../libs/client/apiClient';
-// import { gridStyles } from '../../constants/styles';
+import { gridStyles } from '../../constants/styles';
 
 export default function DealsDataLeadgen(props) {
   const navigate = useNavigate();
@@ -48,12 +48,6 @@ export default function DealsDataLeadgen(props) {
 
   //STYLES:
 
-  const gridStyles = {
-    height: 350,
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto' // allow scrolling within the grid if content exceeds its bounds
-  };
-
   const apiRef = React.useRef(null);
 
   //CHANGE THE COLUMNS AND THOSE FIELDS THAT ARE ADDED TO IT.
@@ -61,7 +55,7 @@ export default function DealsDataLeadgen(props) {
   const columns = useMemo(
     () => [
       {
-        field: 'Profile',
+        field: 'profile',
         headerName: 'Profile',
         width: 150,
         editable: true,
@@ -144,7 +138,7 @@ export default function DealsDataLeadgen(props) {
 
       {
         field: 'ppwFinal',
-        headerName: 'PpwFinal',
+        headerName: 'PPW Final',
         width: 500,
         editable: false,
         hide: false
@@ -320,12 +314,10 @@ export default function DealsDataLeadgen(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: 350 }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               //rows={leadsRows}
               rows={filteredRows}

--- a/client/src/components/dataGrid/InactiveRates.jsx
+++ b/client/src/components/dataGrid/InactiveRates.jsx
@@ -1,6 +1,6 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -22,12 +22,6 @@ export default function InActiveRates(props) {
   const { recordUserId } = props;
 
   // Grid style
-  const gridStyles = {
-    height: 350,
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto' // allow scrolling within the grid if content exceeds its bounds
-  };
-
   const [gridRef] = useState({});
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -123,7 +117,7 @@ export default function InActiveRates(props) {
       },
       {
         field: 'id',
-        headerName: 'id',
+        headerName: 'ID',
         width: 500,
         editable: false,
         hide: true
@@ -253,9 +247,7 @@ export default function InActiveRates(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
               pageSize={pageSize}
@@ -264,7 +256,7 @@ export default function InActiveRates(props) {
               paginationMode="server"
               onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
               onPageChange={(newPage) => setPage(newPage)}
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: 350 }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               rows={leadsRows}
               editable

--- a/client/src/components/dataGrid/LeadGenPay.jsx
+++ b/client/src/components/dataGrid/LeadGenPay.jsx
@@ -1,6 +1,6 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -22,12 +22,6 @@ export default function LeadGenPay(props) {
   const { recordUserId } = props;
 
   // Grid style
-  const gridStyles = {
-    height: 350,
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto' // allow scrolling within the grid if content exceeds its bounds
-  };
-
   const [gridRef] = useState({});
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -80,7 +74,7 @@ export default function LeadGenPay(props) {
 
       {
         field: 'saleDate',
-        headerName: 'SaleDate',
+        headerName: 'Sale Date',
         width: 180,
         editable: false,
         hide: false,
@@ -335,9 +329,7 @@ export default function LeadGenPay(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
               pageSize={pageSize}
@@ -346,7 +338,7 @@ export default function LeadGenPay(props) {
               paginationMode="server"
               onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
               onPageChange={(newPage) => setPage(newPage)}
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: 350 }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               rows={leadsRows}
               editable

--- a/client/src/components/dataGrid/NewSaleData.jsx
+++ b/client/src/components/dataGrid/NewSaleData.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import { Button, TextField, Typography, Modal, Box, CircularProgress, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Modal, Box, Skeleton, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 import { DataGridPro, GridToolbar } from '@mui/x-data-grid-pro';
 import { baseURL } from '../../libs/client/apiClient';
 import axios from 'axios';
@@ -485,10 +485,8 @@ export default function NewSaleData(props) {
       </Box>
       <div style={{ height: 400, width: '100%' }}>
         {isLoading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-            <CircularProgress />
-          </Box>
-        ) : error ? (
+          <Skeleton variant="rectangular" width="100%" height="100%" />
+          ) : error ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
             <Typography color="error">{error}</Typography>
           </Box>

--- a/client/src/components/dataGrid/PayrollData.jsx
+++ b/client/src/components/dataGrid/PayrollData.jsx
@@ -1,6 +1,6 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 
 import { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -29,12 +29,6 @@ export default function PayrollData(props) {
   };
 
   // Grid style
-  const gridStyles = {
-    height: 350,
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto' // allow scrolling within the grid if content exceeds its bounds
-  };
-
   const [gridRef] = useState({});
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -87,7 +81,7 @@ export default function PayrollData(props) {
 
       {
         field: 'saleDate',
-        headerName: 'SaleDate',
+        headerName: 'Sale Date',
         width: 180,
         editable: false,
         hide: false,
@@ -375,9 +369,7 @@ export default function PayrollData(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
               pageSize={pageSize}
@@ -386,7 +378,7 @@ export default function PayrollData(props) {
               paginationMode="server"
               onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
               onPageChange={(newPage) => setPage(newPage)}
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: 350 }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               rows={leadsRows}
               editable

--- a/client/src/components/dataGrid/PreviousPayData.jsx
+++ b/client/src/components/dataGrid/PreviousPayData.jsx
@@ -1,7 +1,7 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
 
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 
 import { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -10,8 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { DataGridPro, GridToolbar } from '@mui/x-data-grid-pro';
 import { styled, darken, lighten } from '@mui/material/styles';
 import { baseURL } from '../../libs/client/apiClient';
-
-// import { gridStyles } from '../../constants/styles';
+import { gridStyles } from '../../constants/styles';
 
 export default function PreviousgPayData(props) {
 
@@ -53,20 +52,13 @@ export default function PreviousgPayData(props) {
 
   //STYLES:
 
-  const gridStyles = {
-    height: '75vh',
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto', // allow scrolling within the grid if content exceeds its bounds
-    backgroundColor: 'none'
-  };
-
   const apiRef = React.useRef(null);
 
   //CHANGE THE COLUMNS AND THOSE FIELDS THAT ARE ADDED TO IT.
   const columns = useMemo(
     () => [
       {
-        field: 'Profile',
+        field: 'profile',
         headerName: 'Profile',
         width: 150,
         editable: true,
@@ -116,7 +108,7 @@ export default function PreviousgPayData(props) {
       },
       {
         field: 'salesRep',
-        headerName: 'salesRep',
+        headerName: 'Sales Rep',
         width: 180,
         editable: false,
         type: 'text'
@@ -297,12 +289,10 @@ export default function PreviousgPayData(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: '75vh', backgroundColor: 'none' }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               //    rows={leadsRows}
               rows={filteredRows}

--- a/client/src/components/dataGrid/RookieLeadgens.jsx
+++ b/client/src/components/dataGrid/RookieLeadgens.jsx
@@ -1,6 +1,6 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 
 import { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { DataGridPro, GridToolbar } from '@mui/x-data-grid-pro';
 import { styled, darken, lighten } from '@mui/material/styles';
 import { baseURL } from '../../libs/client/apiClient';
-// import { gridStyles } from '../../constants/styles';
+import { gridStyles } from '../../constants/styles';
 
 export default function RookieDataLead(props) {
   const navigate = useNavigate();
@@ -48,19 +48,13 @@ export default function RookieDataLead(props) {
 
   //STYLES:
 
-  const gridStyles = {
-    height: 350,
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto' // allow scrolling within the grid if content exceeds its bounds
-  };
-
   const apiRef = React.useRef(null);
 
   //CHANGE THE COLUMNS AND THOSE FIELDS THAT ARE ADDED TO IT.
   const columns = useMemo(
     () => [
       {
-        field: 'Profile',
+        field: 'profile',
         headerName: 'Profile',
         width: 150,
         editable: true,
@@ -80,7 +74,7 @@ export default function RookieDataLead(props) {
       },
       {
         field: 'saleDate',
-        headerName: 'SaleDate',
+        headerName: 'Sale Date',
         width: 180,
         editable: false,
         hide: false,
@@ -159,14 +153,14 @@ export default function RookieDataLead(props) {
 
       {
         field: 'ppwFinal',
-        headerName: 'PpwFinal',
+        headerName: 'PPW Final',
         width: 500,
         editable: false,
         hide: false
       },
       {
         field: 'id',
-        headerName: 'id',
+        headerName: 'ID',
         width: 500,
         editable: false,
         hide: true
@@ -344,12 +338,10 @@ export default function RookieDataLead(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: 350 }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               rows={leadsRows}
               editable

--- a/client/src/components/dataGrid/RookiesData.jsx
+++ b/client/src/components/dataGrid/RookiesData.jsx
@@ -1,6 +1,6 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 
 import { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { DataGridPro, GridToolbar } from '@mui/x-data-grid-pro';
 import { styled, darken, lighten } from '@mui/material/styles';
 import { baseURL } from '../../libs/client/apiClient';
-// import { gridStyles } from '../../constants/styles';
+import { gridStyles } from '../../constants/styles';
 
 export default function RookieData(props) {
   const navigate = useNavigate();
@@ -48,19 +48,13 @@ export default function RookieData(props) {
 
   //STYLES:
 
-  const gridStyles = {
-    height: 350,
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto' // allow scrolling within the grid if content exceeds its bounds
-  };
-
   const apiRef = React.useRef(null);
 
   //CHANGE THE COLUMNS AND THOSE FIELDS THAT ARE ADDED TO IT.
   const columns = useMemo(
     () => [
       {
-        field: 'Profile',
+        field: 'profile',
         headerName: 'Profile',
         width: 150,
         editable: true,
@@ -80,7 +74,7 @@ export default function RookieData(props) {
       },
       {
         field: 'saleDate',
-        headerName: 'SaleDate',
+        headerName: 'Sale Date',
         width: 180,
         editable: false,
         hide: false,
@@ -159,14 +153,14 @@ export default function RookieData(props) {
 
       {
         field: 'ppwFinal',
-        headerName: 'PpwFinal',
+        headerName: 'PPW Final',
         width: 500,
         editable: false,
         hide: false
       },
       {
         field: 'id',
-        headerName: 'id',
+        headerName: 'ID',
         width: 500,
         editable: false,
         hide: true
@@ -344,12 +338,10 @@ export default function RookieData(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: 350 }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               rows={leadsRows}
               editable

--- a/client/src/components/dataGrid/UpcomingPay.jsx
+++ b/client/src/components/dataGrid/UpcomingPay.jsx
@@ -1,7 +1,7 @@
 // TODO: add subscription to update the table when a new lead is added, NEW_LEAD_SUBSCRIPTION
 import * as React from 'react';
 
-import { Button, TextField, Typography, CircularProgress, Select, MenuItem } from '@mui/material';
+import { Button, TextField, Typography, Skeleton, Select, MenuItem } from '@mui/material';
 
 import { useMemo, useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { DataGridPro, GridToolbar } from '@mui/x-data-grid-pro';
 import { styled, darken, lighten } from '@mui/material/styles';
 import { baseURL } from '../../libs/client/apiClient';
-// import { gridStyles } from '../../constants/styles';
+import { gridStyles } from '../../constants/styles';
 
 export default function UpcomingPayData(props) {
 
@@ -52,20 +52,13 @@ export default function UpcomingPayData(props) {
 
   //STYLES:
 
-  const gridStyles = {
-    height: '75vh',
-    maxWidth: '100%', // ensure the grid does not exceed the width of its container
-    overflow: 'auto', // allow scrolling within the grid if content exceeds its bounds
-    backgroundColor: 'none'
-  };
-
   const apiRef = React.useRef(null);
 
   //CHANGE THE COLUMNS AND THOSE FIELDS THAT ARE ADDED TO IT.
   const columns = useMemo(
     () => [
       {
-        field: 'Profile',
+        field: 'profile',
         headerName: 'Profile',
         width: 150,
         editable: true,
@@ -92,7 +85,7 @@ export default function UpcomingPayData(props) {
       },
       {
         field: 'milestone',
-        headerName: 'MileStone',
+        headerName: 'Milestone',
         width: 180,
         editable: false,
         type: 'text'
@@ -101,7 +94,7 @@ export default function UpcomingPayData(props) {
     
       {
         field: 'plansReqDate',
-        headerName: 'Plans Requeated Date',
+        headerName: 'Plans Requested Date',
         width: 180,
         editable: false,
         type: 'text'
@@ -130,14 +123,14 @@ export default function UpcomingPayData(props) {
       },
       {
         field: 'contractAmount',
-        headerName: 'ContractAmount',
+        headerName: 'Contract Amount',
         width: 180,
         editable: false,
         type: 'text'
       },
       {
         field: 'salesRep',
-        headerName: 'salesRep',
+        headerName: 'Sales Rep',
         width: 180,
         editable: false,
         type: 'text'
@@ -322,12 +315,10 @@ export default function UpcomingPayData(props) {
           </Box>
 
           {isLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-              <CircularProgress />
-            </Box>
+            <Skeleton variant="rectangular" width="100%" height="100%" />
           ) : (
             <StyledDataGrid
-              sx={gridStyles}
+              sx={{ ...gridStyles, height: '75vh', backgroundColor: 'none' }}
               //  rows={categories.length || searchQuery ? data?.leads?.rows : leadsRows}  columns={columnsToShow}
               //    rows={leadsRows}
               rows={filteredRows}

--- a/client/src/constants/styles.js
+++ b/client/src/constants/styles.js
@@ -1,43 +1,4 @@
 export const gridStyles = {
-    root: {
-      '& .MuiDataGrid-root': {
-        backgroundColor: '#fff',
-        border: '1px solid #ddd',
-      },
-      '& .MuiDataGrid-columnsContainer': {
-        backgroundColor: '#f5f5f5',
-        borderBottom: '1px solid #ddd',
-      },
-      '& .MuiDataGrid-columnHeader': {
-        fontWeight: 'bold',
-        color: '#333',
-      },
-      '& .MuiDataGrid-cell': {
-        borderBottom: '1px solid rgba(224, 224, 224, 1)',
-      },
-      '& .MuiDataGrid-cell:nth-of-type(even)': {
-        backgroundColor: 'rgba(0, 0, 0, 0.04)',
-      },
-      '& .MuiDataGrid-cell:last-child': {
-        borderRight: 'none',
-      },
-      '& .MuiDataGrid-cellEditable': {
-        backgroundColor: '#fff',
-        '& input': {
-          color: '#333',
-        },
-      },
-      '& .MuiDataGrid-cell--textLeft': {
-        textAlign: 'left',
-      },
-      '& .MuiDataGrid-cell--textCenter': {
-        textAlign: 'center',
-      },
-      '& .MuiDataGrid-cell--textRight': {
-        textAlign: 'right',
-      },
-    },
-   };
-  
-  
-  
+  maxWidth: '100%',
+  overflow: 'auto'
+};


### PR DESCRIPTION
## Summary
- centralize DataGrid style constants
- implement loading skeletons instead of spinners
- fix column field case and headers for consistency

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*