### PR TITLE
Remove stray console logs

### DIFF
--- a/client/src/components/add-user-form/AddUser.tsx
+++ b/client/src/components/add-user-form/AddUser.tsx
@@ -7,6 +7,7 @@ import { MultiSelect } from 'react-multi-select-component';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { format } from 'date-fns';
+import logger from '../../utils/logger';
 
 const AddUserForm = ({ onClose }) => {
   const [formData, setFormData] = useState({
@@ -88,7 +89,7 @@ const AddUserForm = ({ onClose }) => {
 
     try {
       const response = await axios.post(API_ENDPOINT, requestBody, { headers });
-      console.log("Success!", response.data);
+      logger.success("Success!", response.data);
       setTimeout(() => {
         onClose(); // Close the modal after 2 seconds
       }, 2000);

--- a/client/src/components/dataGrid/ActiveRates.jsx
+++ b/client/src/components/dataGrid/ActiveRates.jsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Box from '@mui/material/Box';
 
 import { DataGridPro, GridToolbar, GroupingPanel } from '@mui/x-data-grid-pro';
+import logger from '../../utils/logger';
 
 import { useAppSelector } from '../../hooks/hooks';
 import { authSelector } from '../../redux/slice/authSlice';
@@ -135,9 +136,9 @@ export default function ActiveRates(props) {
     })
       .then((response) => response.json())
       .then((responseData) => {
-        console.log(responseData.data.rates);
+        logger.request(responseData.data.rates);
 
-        console.log('responseData.data.payrollData:', responseData.data.rates);
+        logger.request('responseData.data.payrollData:', responseData.data.rates);
 
         if (responseData.success && responseData.data.rates) {
           const RateData = responseData.data.rates.map((feeRateItem, index) => {

--- a/client/src/components/dataGrid/InactiveRates.jsx
+++ b/client/src/components/dataGrid/InactiveRates.jsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Box from '@mui/material/Box';
 
 import { DataGridPro, GridToolbar, GroupingPanel } from '@mui/x-data-grid-pro';
+import logger from '../../utils/logger';
 
 import { useAppSelector } from '../../hooks/hooks';
 import { authSelector } from '../../redux/slice/authSlice';
@@ -135,9 +136,9 @@ export default function InActiveRates(props) {
     })
       .then((response) => response.json())
       .then((responseData) => {
-        console.log(responseData.data.rates);
+        logger.request(responseData.data.rates);
 
-        console.log('responseData.data.payrollData:', responseData.data.rates);
+        logger.request('responseData.data.payrollData:', responseData.data.rates);
 
         if (responseData.success && responseData.data.rates) {
           const RateData = responseData.data.rates.map((feeRateItem, index) => {

--- a/client/src/components/dataGrid/LeadGenPay.jsx
+++ b/client/src/components/dataGrid/LeadGenPay.jsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Box from '@mui/material/Box';
 
 import { DataGridPro, GridToolbar, GroupingPanel } from '@mui/x-data-grid-pro';
+import logger from '../../utils/logger';
 
 import { useAppSelector } from '../../hooks/hooks';
 import { authSelector } from '../../redux/slice/authSlice';
@@ -203,9 +204,9 @@ export default function LeadGenPay(props) {
     })
       .then((response) => response.json())
       .then((responseData) => {
-        console.log(responseData.data.payrollData);
+        logger.request(responseData.data.payrollData);
 
-        console.log('responseData.data.payrollData:', responseData.data.payrollData);
+        logger.request('responseData.data.payrollData:', responseData.data.payrollData);
 
         if (responseData.success && responseData.data.payrollData) {
           const payData = responseData.data.payrollData.map((payrollItem) => {

--- a/client/src/components/dataGrid/NewSaleData.jsx
+++ b/client/src/components/dataGrid/NewSaleData.jsx
@@ -7,6 +7,7 @@ import { startOfDay, startOfWeek, startOfMonth, startOfYear, isWithinInterval } 
 import Autocomplete from 'react-google-autocomplete';
 import { useCallback } from 'react';
 import PlacesAutocomplete from 'react-places-autocomplete';
+import logger from '../../utils/logger';
 
 
 
@@ -103,8 +104,6 @@ const EditModal = ({ open, onClose, data, onSave }) => {
 
   const submitMissingData = async (e) => {
 
-    console.log("formData")
-    console.log(formData);
     e.preventDefault();
     const headers = {
       Authorization: "QB-USER-TOKEN b7738j_qjt3_0_dkaew43bvzcxutbu9q4e6crw3ei3",
@@ -127,7 +126,7 @@ const EditModal = ({ open, onClose, data, onSave }) => {
   
     try {
       const response = await axios.post("https://api.quickbase.com/v1/records", requestBody, { headers });
-      console.log("Success!", response.data);
+      logger.success("Success!", response.data);
       pushNewProject(e)
       setIsSubmitted(true);
       onClose(); // Close the modal here
@@ -172,10 +171,7 @@ const EditModal = ({ open, onClose, data, onSave }) => {
     
 
 
-    console.log("pushing new project" , formData)
 
-
-    console.log("pushing new project" , formData)
   
     const requestBody = {
       to: "br5cqr4r3",
@@ -197,7 +193,7 @@ const EditModal = ({ open, onClose, data, onSave }) => {
 
     try {
       const response = await axios.post(API_ENDPOINT, requestBody, { headers });
-      console.log("Success!", response.data);
+      logger.success("Success!", response.data);
       setIsSubmitted(true);
 
       onClose(); // Close the modal here
@@ -385,7 +381,6 @@ export default function NewSaleData(props) {
 
   const handleOpenModal = (row) => {
 
-    console.log("Selected Row:", row);  // This logs correctly, including recordID
   
 
   
@@ -404,13 +399,11 @@ export default function NewSaleData(props) {
     setSelectedRow(row);
 
 
-    console.log(selectedRow)
     setOpenModal(true);
   };
 
   const handleCloseModal = () => {
 
-    console.log( selectedRow)
     setOpenModal(false);
     setSelectedRow(null);
     setFormData({});

--- a/client/src/components/dataGrid/PayrollData.jsx
+++ b/client/src/components/dataGrid/PayrollData.jsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Box from '@mui/material/Box';
 import { useNavigate } from 'react-router-dom';
 import { DataGridPro, GridToolbar, GroupingPanel } from '@mui/x-data-grid-pro';
+import logger from '../../utils/logger';
 
 import { useAppSelector } from '../../hooks/hooks';
 import { authSelector } from '../../redux/slice/authSlice';
@@ -225,9 +226,9 @@ export default function PayrollData(props) {
     })
       .then((response) => response.json())
       .then((responseData) => {
-        console.log(responseData.data.payrollData);
+        logger.request(responseData.data.payrollData);
 
-        console.log('responseData.data.payrollData:', responseData.data.payrollData);
+        logger.request('responseData.data.payrollData:', responseData.data.payrollData);
 
         if (responseData.success && responseData.data.payrollData) {
           const payData = responseData.data.payrollData.map((payrollItem) => {

--- a/client/src/components/email-user/EmailUser.tsx
+++ b/client/src/components/email-user/EmailUser.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { TextField, Button, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 import axios from 'axios';
+import logger from '../utils/logger';
 
 const EmailUserForm = () => {
   const [formData, setFormData] = useState({
@@ -25,7 +26,7 @@ const EmailUserForm = () => {
 
     try {
       const response = await axios.post(API_ENDPOINT, requestBody, { headers });
-      console.log("Success!", response.data);
+      logger.success("Success!", response.data);
       // Add any additional actions on success here
     } catch (error) {
       alert("Failed sending email");

--- a/client/src/components/send-letter/SendLetter.jsx
+++ b/client/src/components/send-letter/SendLetter.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { TextField, Button, MenuItem, Select, InputLabel, FormControl, Checkbox, ListItemText } from '@mui/material';
 import axios from 'axios';
+import logger from '../../utils/logger';
 
 const MessageForm = ({ onClose }) => {
   const [formData, setFormData] = useState({
@@ -70,7 +71,7 @@ const MessageForm = ({ onClose }) => {
 
     try {
       const response = await axios.post(API_ENDPOINT, requestBody, { headers });
-      console.log("Success!", response.data);
+      logger.success("Success!", response.data);
       setSubmissionStatus({
         success: true,
         message: 'Message, Topic, and Receiver roles sent successfully!',

--- a/client/src/components/upload-file/CsvUpload.tsx
+++ b/client/src/components/upload-file/CsvUpload.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import Papa from 'papaparse';
+import logger from '../../utils/logger';
 
 // const CsvUpload = (props) => {
 interface CsvUploadProps {
@@ -27,7 +28,7 @@ function CsvUpload({ handleCsvData }: CsvUploadProps) {
 
   const handleLeadSubmit = (e) => {
     e.preventDefault();
-    console.log('Lead Submitted!');
+    logger.success('Lead Submitted!');
   };
 
   const handleFileUpload = (event) => {
@@ -51,7 +52,7 @@ function CsvUpload({ handleCsvData }: CsvUploadProps) {
     // Check Uploaded EALERTS
 
     data.forEach((lead) => {
-      console.log(lead);
+      logger.request(lead);
     });
     alert('File uploaded!');
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,6 +8,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 // import reportWebVitals from "./reportWebVitals";
 import App from './App';
 import { store, persistor } from './redux/store';
+import logger from './utils/logger';
 
 // Function to load the Google Maps API
 const loadGoogleMapsAPI = (callback: () => void) => {
@@ -28,7 +29,7 @@ const loadGoogleMapsAPI = (callback: () => void) => {
 const RootComponent = () => {
   useEffect(() => {
     loadGoogleMapsAPI(() => {
-      console.log('Google Maps API has been loaded');
+      logger.success('Google Maps API has been loaded');
     });
   }, []);
 

--- a/client/src/pages/LeadDetailPage.jsx
+++ b/client/src/pages/LeadDetailPage.jsx
@@ -9,6 +9,7 @@ import PersonIcon from '@mui/icons-material/Person';
 import { useParams } from 'react-router-dom';
 import { useAppSelector } from '../hooks/hooks';
 import { authSelector } from '../redux/slice/authSlice';
+import logger from '../utils/logger';
 
 
 
@@ -67,7 +68,7 @@ const LeadDetailPage = () => {
 
     // Function to update stages
     const updateStages = (data) => {
-      console.log("Updating stages with data:", data);
+      logger.request('Updating stages with data:', data);
       setTaskDates({
         saleDate: data.saleDate ? data.saleDate.replace(/^"|"$/g, '') : null,
         welcomeDate: data.welcomeDate ? data.welcomeDate.replace(/^"|"$/g, '') : null,

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -18,6 +18,7 @@ import Iconify from '../components/iconify';
 import { useAppDispatch, useAppSelector } from '../hooks/hooks';
 import { login } from '../redux/middleware/authentication';
 import { setAlert } from '../redux/slice/alertSlice';
+import logger from '../utils/logger';
 import { authSelector } from '../redux/slice/authSlice';
 
 const LoginPage = () => {
@@ -66,7 +67,7 @@ const LoginPage = () => {
           type: 'error'
         })
       );
-      console.log(error);
+      logger.error(error);
     }
   };
   return (

--- a/client/src/pages/RegisterPage.tsx
+++ b/client/src/pages/RegisterPage.tsx
@@ -20,6 +20,7 @@ import AuthenticationLayout from '../layouts/AuthenticationLayout';
 import Iconify from '../components/iconify';
 import { RegisterOrgTypes } from '../types';
 import { baseURL } from '../libs/client/apiClient';
+import logger from '../utils/logger';
 
 const initialState = {
   email: '',
@@ -56,7 +57,7 @@ const RegisterPage = () => {
         setIsCodeSent(true);
       }
     } catch (error) {
-      console.log(error);
+      logger.error(error);
     }
   };
   const handleRegister = async (data: RegisterOrgTypes) => {
@@ -68,13 +69,13 @@ const RegisterPage = () => {
         password: data.password,
         verificationToken: data.verifyCode
       });
-      console.log(response);
+      logger.success(response);
 
       if (response.status === 200) {
         navigate('/login');
       }
     } catch (error) {
-      console.log(error);
+      logger.error(error);
     }
   };
   return (

--- a/client/src/sections/@dashboard/app/AppTasks.js
+++ b/client/src/sections/@dashboard/app/AppTasks.js
@@ -14,6 +14,7 @@ import {
   CardHeader,
   FormControlLabel,
 } from '@mui/material';
+import logger from '../../../utils/logger';
 // components
 import Iconify from '../../../components/iconify';
 
@@ -84,22 +85,22 @@ function TaskItem({ task, checked, onChange }) {
 
   const handleMarkComplete = () => {
     handleCloseMenu();
-    console.log('MARK COMPLETE', task.id);
+    logger.success('MARK COMPLETE', task.id);
   };
 
   const handleShare = () => {
     handleCloseMenu();
-    console.log('SHARE', task.id);
+    logger.success('SHARE', task.id);
   };
 
   const handleEdit = () => {
     handleCloseMenu();
-    console.log('EDIT', task.id);
+    logger.success('EDIT', task.id);
   };
 
   const handleDelete = () => {
     handleCloseMenu();
-    console.log('DELETE', task.id);
+    logger.success('DELETE', task.id);
   };
 
   return (

--- a/client/src/serviceWorker.js
+++ b/client/src/serviceWorker.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 /* @ts-nocheck */
+import logger from './utils/logger';
 
 // This optional code is used to register a service worker.
 // register() is not called by default.
@@ -40,8 +41,7 @@ export function register(config) {
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
-          console.log('This web app is being served cache-first by a service ' +
-            'worker. To learn more, visit https://bit.ly/CRA-PWA');
+          logger.success('This web app is being served cache-first by a service worker. To learn more, visit https://bit.ly/CRA-PWA');
         });
       } else {
         // Is not localhost. Just register service worker
@@ -67,8 +67,7 @@ function registerValidSW(swUrl, config) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
-              console.log('New content is available and will be used when all ' +
-                'tabs for this page are closed. See https://bit.ly/CRA-PWA.');
+              logger.warn('New content is available and will be used when all tabs for this page are closed. See https://bit.ly/CRA-PWA.');
 
               // Execute callback
               if (config && config.onUpdate) {
@@ -78,7 +77,7 @@ function registerValidSW(swUrl, config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              logger.success('Content is cached for offline use.');
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -116,7 +115,7 @@ function checkValidServiceWorker(swUrl, config) {
       }
     })
     .catch(() => {
-      console.log('No internet connection found. App is running in offline mode.');
+      logger.warn('No internet connection found. App is running in offline mode.');
     });
 }
 

--- a/client/src/utils/logger.ts
+++ b/client/src/utils/logger.ts
@@ -1,0 +1,17 @@
+export const emoji = {
+  request: '➡️',
+  success: '✅',
+  warn: '⚠️',
+  error: '❌',
+  retry: '🔄'
+};
+
+const logger = {
+  request: (...args: any[]) => console.log(emoji.request, ...args),
+  success: (...args: any[]) => console.log(emoji.success, ...args),
+  warn: (...args: any[]) => console.warn(emoji.warn, ...args),
+  error: (...args: any[]) => console.error(emoji.error, ...args),
+  retry: (...args: any[]) => console.log(emoji.retry, ...args)
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- introduce simple emoji logger for frontend
- replace stray `console.log` calls with logger
- clean out leftover debugging logs

## Testing
- `npm test --workspaces` *(fails: react-scripts not found)*