### PR TITLE
Replace Yarn invocation in server test script

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,7 @@
     "start:prod": "cross-env NODE_ENV=production node dist/index.js",
     "bundle": "tsc && cross-env NODE_ENV=production webpack",
     "start:bundle": "cross-env NODE_ENV=production node dist/app.bundle.js",
-    "test": "yarn run test:lint && yarn run test:coverage",
+    "test": "npm run test:lint && npm run test:coverage",
     "test:unit": "cross-env NODE_ENV=test jest",
     "test:coverage": "jest --coverage",
     "test:watch": "cross-env NODE_ENV=test jest --watch",


### PR DESCRIPTION
## Summary
- switch the server's `test` script from Yarn to npm so `npm --prefix server test` doesn't require Yarn

## Testing
- `npm --prefix server test` *(fails: missing `@typescript-eslint/eslint-plugin`)*