### PR TITLE
Run tests once and split results

### DIFF
--- a/scripts/split-jest-results.js
+++ b/scripts/split-jest-results.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const resultsFile = path.join(root, 'jest-results.json');
+const serverFile = path.join(root, 'jest-server-results.json');
+const clientFile = path.join(root, 'jest-client-results.json');
+
+if (!fs.existsSync(resultsFile)) {
+  console.error(`Results file not found at ${resultsFile}`);
+  process.exit(0);
+}
+
+const data = JSON.parse(fs.readFileSync(resultsFile, 'utf8'));
+const suites = data.testResults || [];
+const serverSuites = [];
+const clientSuites = [];
+for (const suite of suites) {
+  const name = suite.name || '';
+  if (name.includes(`${path.sep}server${path.sep}`) || name.includes('tests/server')) {
+    serverSuites.push(suite);
+  } else if (name.includes(`${path.sep}client${path.sep}`) || name.includes('tests/client')) {
+    clientSuites.push(suite);
+  }
+}
+
+function buildResult(list) {
+  return { ...data, testResults: list };
+}
+
+fs.writeFileSync(serverFile, JSON.stringify(buildResult(serverSuites), null, 2));
+fs.writeFileSync(clientFile, JSON.stringify(buildResult(clientSuites), null, 2));
+console.log(`Split results written to:\n- ${serverFile}\n- ${clientFile}`);

--- a/setup.sh
+++ b/setup.sh
@@ -40,11 +40,11 @@ echo "🔧  Preparing client for install..."
 )
 
 # ─── 6) Run integrated test suites with Jest ───────────────────────────────────
-echo "🧪  Running server test suite..."
-( cd server && npm test -- --json --outputFile=jest-server-results.json ) || { echo "❌  Server tests failed. Results saved to jest-server-results.json"; }
+echo "🧪  Running all test suites..."
+npm test || { echo "❌  Tests failed"; }
 
-echo "🧪  Running client test suite..."
-( cd client && npm test -- --config='{"collectCoverage": false, "setupFilesAfterEnv": []}' --json --outputFile=jest-client-results.json ) || { echo "❌  Client tests failed. Results saved to jest-client-results.json"; }
+# Split the combined results into per-project files
+node scripts/split-jest-results.js || true
 
 echo "✅  Test run complete. Codex can now analyze the results files"
 


### PR DESCRIPTION
## Summary
- run Jest a single time in `setup.sh`
- extract server and client results via `split-jest-results.js`

## Testing
- `npm test` *(fails: jest not found)*