### PR TITLE
Fix missing jest results handling

### DIFF
--- a/scripts/process-jest-results.js
+++ b/scripts/process-jest-results.js
@@ -38,7 +38,7 @@ function summarizeSuites(suites) {
 function main() {
   if (!fs.existsSync(resultsPath)) {
     console.error(`Results file not found at ${resultsPath}`);
-    return;
+    return { testResults: [] };
   }
   const data = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
   const suites = data.testResults || [];


### PR DESCRIPTION
## Summary
- make `process-jest-results.js` return an empty result object when `jest-results.json` is absent

## Testing
- `npm test` *(fails: jest not found)*