### PR TITLE
Silence root test output

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "npm run dev",
     "server": "cd server && npm run dev",
     "client": "cd client && npm run dev",
-    "test": "jest --config=jest.config.js --json --outputFile=jest-results.json"
+    "test": "jest --config=jest.config.js --silent --outputFile=jest-results.json"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## Summary
- make root test script quiet with `--silent`

## Testing
- `npm test` *(fails: jest not found)*