### PR TITLE
Fix EmojiAppender test log level

### DIFF
--- a/server/src/util/__tests__/emojiAppender.test.ts
+++ b/server/src/util/__tests__/emojiAppender.test.ts
@@ -2,6 +2,13 @@ import "../../config/logger";
 import { $log } from "@tsed/common";
 
 describe("EmojiAppender", () => {
+  const originalLevel = $log.level;
+  beforeEach(() => {
+    $log.level = "info";
+  });
+  afterEach(() => {
+    $log.level = originalLevel;
+  });
   it("summarizes object info logs", () => {
     const spy = jest.spyOn(process.stdout, "write").mockImplementation(() => true as any);
     $log.info({ b: 1, a: 2, d: 3, c: 4 });


### PR DESCRIPTION
## Summary
- ensure emoji logs are emitted by setting `$log.level = 'info'` during EmojiAppender tests

## Testing
- `npm test` *(fails: jest not found)*