### PR TITLE
Switch router to localStorage token

### DIFF
--- a/client/src/routes.js
+++ b/client/src/routes.js
@@ -18,16 +18,15 @@ import RegisterPage from './pages/RegisterPage';
 
 
 export default function Router() {
-  let session = document.cookie.split(';').find((item) => item.includes('session'));
-  session = session ? session.split('=')[1] : null;
+  const token = localStorage.getItem('token');
   const routes = useRoutes([
     {
       path: '/',
-      element: session ? <Navigate to="/dashboard/deals" replace /> : <LandingPage />,
+      element: token ? <Navigate to="/dashboard/deals" replace /> : <LandingPage />,
     },
     {
       path: '/dashboard',
-      element: session ? <DashboardLayout /> : <Navigate to="/login" replace />,
+      element: token ? <DashboardLayout /> : <Navigate to="/login" replace />,
       children: [
         { index: true, element: <Navigate to="/dashboard/deals" /> },
         { path: 'deals', element: <DealsPage /> },

--- a/tests/client/routes/Routes.test.tsx
+++ b/tests/client/routes/Routes.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Router from '../../../client/src/routes';
+
+describe('Router token based routing', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders landing page when no token on root path', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}> 
+        <Router />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Welcome to Voltaic CRM/i)).toBeInTheDocument();
+  });
+
+  it('redirects to login when visiting protected route without token', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}> 
+        <Router />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Welcome Back!/i)).toBeInTheDocument();
+  });
+
+  it('shows dashboard content when token exists', () => {
+    window.localStorage.setItem('token', 'abc');
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}> 
+        <Router />
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/Projects/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- check `localStorage.getItem('token')` in the router
- add routing tests for login redirects and token usage

## Testing
- `npm test` *(fails: jest not found)*