### PR TITLE
Add AuthContext to client-2

### DIFF
--- a/client-2/src/api/auth.ts
+++ b/client-2/src/api/auth.ts
@@ -1,0 +1,20 @@
+export async function login(email: string, password: string) {
+  const res = await fetch('/rest/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password })
+  });
+
+  let data: any = null;
+  try {
+    data = await res.json();
+  } catch (err) {
+    // ignore json parse errors
+  }
+
+  if (!res.ok) {
+    throw new Error(data?.message || 'Login failed');
+  }
+
+  return data;
+}

--- a/client-2/src/context/AuthContext.tsx
+++ b/client-2/src/context/AuthContext.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useState } from 'react';
+import { login as apiLogin } from '../api/auth';
+
+interface AuthState {
+  user: any | null;
+  token: string | null;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => void;
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<any | null>(null);
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('authToken'));
+
+  const signIn = async (email: string, password: string) => {
+    const data = await apiLogin(email, password);
+    const authToken = data?.data?.token;
+    setUser(data?.data || null);
+    setToken(authToken);
+    if (authToken) {
+      localStorage.setItem('authToken', authToken);
+    }
+  };
+
+  const signOut = () => {
+    setUser(null);
+    setToken(null);
+    localStorage.removeItem('authToken');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return ctx;
+};

--- a/client-2/src/index.tsx
+++ b/client-2/src/index.tsx
@@ -3,12 +3,15 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { Provider } from './components/ui/provider';
+import { AuthProvider } from './context/AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
     <Provider>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </Provider>
   </React.StrictMode>
 );

--- a/client-2/src/pages/Login.tsx
+++ b/client-2/src/pages/Login.tsx
@@ -1,22 +1,44 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Box, Button, FormControl, FormLabel, Heading, Input, Stack, Text } from '@chakra-ui/react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../context/AuthContext'
 
 const LoginPage: React.FC = () => {
+  const navigate = useNavigate()
+  const { signIn } = useAuth()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    try {
+      await signIn(email, password)
+      navigate('/dashboard')
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
   return (
     <Box className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-white px-4">
       <Box bg="white" p={8} rounded="xl" shadow="xl" className="w-full max-w-md transition-transform hover:scale-[1.01]">
         <Heading mb={6} size="lg" textAlign="center">Login to Volta</Heading>
-        <Stack spacing={4}>
-          <FormControl>
-            <FormLabel>Email address</FormLabel>
-            <Input type="email" placeholder="you@example.com" />
-          </FormControl>
-          <FormControl>
-            <FormLabel>Password</FormLabel>
-            <Input type="password" />
-          </FormControl>
-          <Button colorScheme="blue" size="md" rounded="md">Sign In</Button>
-        </Stack>
+        {error && <Text color="red.500" mb={2}>{error}</Text>}
+        <form onSubmit={handleSubmit}>
+          <Stack spacing={4}>
+            <FormControl>
+              <FormLabel>Email address</FormLabel>
+              <Input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="you@example.com" />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Password</FormLabel>
+              <Input type="password" value={password} onChange={e => setPassword(e.target.value)} />
+            </FormControl>
+            <Button type="submit" colorScheme="blue" size="md" rounded="md">Sign In</Button>
+          </Stack>
+        </form>
         <Text fontSize="sm" textAlign="center" mt={4} color="gray.500">
           Don't have an account? <a href="#" className="text-blue-600 hover:underline">Sign up</a>
         </Text>


### PR DESCRIPTION
## Summary
- create API helper for auth login
- add React authentication context with signIn and signOut
- persist auth token in localStorage after login
- integrate AuthProvider in index
- update Login page to use context

## Testing
- `npm test` *(fails: jest not found)*