### PR TITLE
Fix import path for AuthProvider

### DIFF
--- a/client-2/src/components/ui/provider.tsx
+++ b/client-2/src/components/ui/provider.tsx
@@ -1,6 +1,6 @@
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 import React from 'react'
-import { AuthProvider } from '../hooks/useAuth'
+import { AuthProvider } from '../../hooks/useAuth'
 
 const theme = extendTheme({
   fonts: { heading: 'Inter, sans-serif', body: 'Inter, sans-serif' },


### PR DESCRIPTION
## Summary
- fix the relative path to `useAuth` in provider component

## Testing
- `npm test` *(fails: jest not found)*