### PR TITLE
Fix AuthContext login params

### DIFF
--- a/client-2/src/context/AuthContext.tsx
+++ b/client-2/src/context/AuthContext.tsx
@@ -15,7 +15,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [token, setToken] = useState<string | null>(() => localStorage.getItem('authToken'));
 
   const signIn = async (email: string, password: string) => {
-    const data = await apiLogin(email, password);
+    const data = await apiLogin({ email, password });
     const authToken = data?.data?.token;
     setUser(data?.data || null);
     setToken(authToken);


### PR DESCRIPTION
## Summary
- update `AuthContext` to pass credentials object to `apiLogin`

## Testing
- `npm test` *(fails: jest not found)*