### PR TITLE
Fix duplicate AuthProvider in client-2

### DIFF
--- a/client-2/src/index.tsx
+++ b/client-2/src/index.tsx
@@ -3,15 +3,12 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { Provider } from './components/ui/provider';
-import { AuthProvider } from './context/AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
     <Provider>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <App />
     </Provider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- remove extra `AuthProvider` wrapper from `client-2/src/index.tsx`

## Testing
- `npx jest` *(fails: request to https://registry.npmjs.org/jest failed)*