### PR TITLE
Fix auth base URL in client-2

### DIFF
--- a/client-2/.env.example
+++ b/client-2/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_STAGE=development

--- a/client-2/src/api/auth.ts
+++ b/client-2/src/api/auth.ts
@@ -4,8 +4,10 @@ export interface Credentials {
   password: string;
 }
 
+import { baseURL } from '../apiConfig';
+
 export async function login(credentials: Credentials) {
-  const response = await fetch('/rest/auth/login', {
+  const response = await fetch(`${baseURL}/auth/login`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'

--- a/client-2/src/apiConfig.ts
+++ b/client-2/src/apiConfig.ts
@@ -1,0 +1,8 @@
+export const urls = {
+  local: 'http://localhost:4000/rest',
+  development: 'http://localhost:4000/rest',
+  production: 'https://voltaiccrm-7dd827fb5012.herokuapp.com/rest'
+};
+
+const env = process.env.REACT_APP_STAGE || 'development';
+export const baseURL = urls[env] || urls.development;

--- a/client-2/src/hooks/useAuth.tsx
+++ b/client-2/src/hooks/useAuth.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState } from 'react';
+import { baseURL } from '../apiConfig';
 
 interface AuthContextProps {
   user: any;
@@ -16,7 +17,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   const signIn = async (email: string, password: string) => {
-    const res = await fetch('/rest/auth/login', {
+    const res = await fetch(`${baseURL}/auth/login`, {
       ...baseOptions,
       body: JSON.stringify({ email, password })
     });

--- a/client-2/src/pages/Register.tsx
+++ b/client-2/src/pages/Register.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { baseURL } from '../apiConfig';
 
 const Register: React.FC = () => {
   const navigate = useNavigate();
@@ -12,7 +13,7 @@ const Register: React.FC = () => {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch('/rest/auth/register', {
+      const res = await fetch(`${baseURL}/auth/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, name, password })


### PR DESCRIPTION
## Summary
- ensure client-2 hits the server on port 4000
- create apiConfig helper to mirror the original client
- update login/register calls to use the configured base URL
- add `.env.example` for client-2

## Testing
- `npm test` *(fails: jest not found)*