### PR TITLE
[VOLTA] Clarify DATABASE_URL setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ npm test
 
 The client now relies on MongoDB only and no QuickBase token is needed.
 
+### Server environment variables
+
+Set `DATABASE_URL` with your MongoDB connection string before starting the
+server. Example:
+
+```dotenv
+DATABASE_URL=mongodb://<user>:<pass>@host:port/dbname
+```
+
+See `server/.env.example` for more variables.
+
 ## Running the applications
 
 ### Start the server only

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,5 @@
-DATABASE_URL=
+# MongoDB connection string
+DATABASE_URL=mongodb://<user>:<pass>@host:port/dbname
 PORT=4000
 NODE_ENV=development
 ENCRYPTION_KEY=

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,7 +32,13 @@ export class Application {
   public async initializeServer() {
     await Secrets.initialize();
     // establish database connection with mongoose.connect()
-    this.databaseConnection = await mongoose.connect(process.env.DATABASE_URL || "");
+    const dbUrl = process.env.DATABASE_URL;
+    if (!dbUrl) {
+      throw new Error(
+        "DATABASE_URL is not set. Please configure it to connect to MongoDB."
+      );
+    }
+    this.databaseConnection = await mongoose.connect(dbUrl);
 
     try {
       this.app = express();


### PR DESCRIPTION
## Summary
- document required `DATABASE_URL` setting in README
- show example in `server/.env.example`
- throw an explicit error if `DATABASE_URL` is missing on server start

## Testing
- `npm run test:lint` *(fails: couldn't find eslint-config-prettier)*
- `npm test` *(fails: jest not found)*