### PR TITLE
[VOLTA] integrate redux with auth and deals slices

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  },
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  verbose: true
+}

--- a/client/package.json
+++ b/client/package.json
@@ -16,13 +16,16 @@
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "framer-motion": "^11.1.3",
-    "react-scripts": "^5.0.1"
+    "react-scripts": "^5.0.1",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.2"
   },
   "devDependencies": {
     "typescript": "^4.9.5",
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.38",
-    "autoprefixer": "^10.4.19"
+    "autoprefixer": "^10.4.19",
+    "@types/react-redux": "^7.1.25"
   },
   "browserslist": {
     "production": [

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,7 +3,8 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import LandingPage from './pages/Landing';
 import Login from './pages/Login';
 import Register from './pages/Register';
-import Deals from './pages/Deals';
+import DashboardDeals from './pages/DashboardDeals';
+import PrivateRoute from './components/PrivateRoute';
 
 const App: React.FC = () => {
   return (
@@ -13,7 +14,14 @@ const App: React.FC = () => {
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
         <Route path="/dashboard" element={<Navigate to="/dashboard/deals" />} />
-        <Route path="/dashboard/deals" element={<Deals />} />
+        <Route
+          path="/dashboard/deals"
+          element={
+            <PrivateRoute>
+              <DashboardDeals />
+            </PrivateRoute>
+          }
+        />
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>

--- a/client/src/components/PrivateRoute.tsx
+++ b/client/src/components/PrivateRoute.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAppSelector } from '../store'
+
+export default function PrivateRoute({ children }: { children: JSX.Element }) {
+  const token = useAppSelector(state => state.auth.token)
+  return token ? children : <Navigate to="/login" replace />
+}

--- a/client/src/components/ui/provider.tsx
+++ b/client/src/components/ui/provider.tsx
@@ -1,6 +1,8 @@
 import { ChakraProvider, extendTheme } from '@chakra-ui/react'
 import React from 'react'
 import { AuthProvider } from '../../hooks/useAuth'
+import { Provider as ReduxProvider } from 'react-redux'
+import { store } from '../../store'
 
 const theme = extendTheme({
   fonts: { heading: 'Inter, sans-serif', body: 'Inter, sans-serif' },
@@ -10,7 +12,9 @@ const theme = extendTheme({
 export function Provider({ children }: { children: React.ReactNode }) {
   return (
     <ChakraProvider theme={theme}>
-      <AuthProvider>{children}</AuthProvider>
+      <ReduxProvider store={store}>
+        <AuthProvider>{children}</AuthProvider>
+      </ReduxProvider>
     </ChakraProvider>
   )
 }

--- a/client/src/pages/DashboardDeals.tsx
+++ b/client/src/pages/DashboardDeals.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react'
+import { Box, Button, List, ListItem, Heading } from '@chakra-ui/react'
+import { fetchDeals } from '../store/dealsSlice'
+import { logout } from '../store/authSlice'
+import { useAppDispatch, useAppSelector } from '../store'
+
+const DashboardDeals: React.FC = () => {
+  const dispatch = useAppDispatch()
+  const deals = useAppSelector(state => state.deals.items)
+
+  useEffect(() => {
+    dispatch(fetchDeals())
+  }, [dispatch])
+
+  const handleLogout = () => {
+    dispatch(logout())
+  }
+
+  return (
+    <Box p={4}>
+      <Button onClick={handleLogout} mb={4} colorScheme="red">
+        Logout
+      </Button>
+      <Heading size="md" mb={2}>Deals</Heading>
+      <List spacing={2}>
+        {deals.map(deal => (
+          <ListItem key={deal.id}>{deal.name}</ListItem>
+        ))}
+      </List>
+    </Box>
+  )
+}
+
+export default DashboardDeals

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,25 +1,28 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Box, Button, FormControl, FormLabel, Heading, Input, Stack, Text } from '@chakra-ui/react'
 import { useNavigate } from 'react-router-dom'
 
-import { useAuth } from '../hooks/useAuth'
+import { useAppDispatch, useAppSelector } from '../store'
+import { login } from '../store/authSlice'
 
 
 const LoginPage: React.FC = () => {
   const navigate = useNavigate()
-  const { signIn } = useAuth()
+  const dispatch = useAppDispatch()
+  const { token, status } = useAppSelector(state => state.auth)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (token) navigate('/dashboard/deals', { replace: true })
+  }, [token, navigate])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
     try {
-      await signIn(email, password)
-
-      navigate('/dashboard/deals', { replace: true })
-
+      await dispatch(login({ email, password })).unwrap()
     } catch (err) {
       setError((err as Error).message)
     }
@@ -46,7 +49,7 @@ const LoginPage: React.FC = () => {
                 {error}
               </Text>
             )}
-            <Button type="submit" colorScheme="blue" size="md" rounded="md">
+            <Button type="submit" colorScheme="blue" size="md" rounded="md" isLoading={status === 'loading'}>
               Sign In
             </Button>
           </Stack>

--- a/client/src/store/authSlice.ts
+++ b/client/src/store/authSlice.ts
@@ -1,0 +1,53 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { login as apiLogin } from '../api/auth'
+
+interface AuthState {
+  user: any | null
+  token: string | null
+  status: 'idle' | 'loading' | 'failed'
+}
+
+const initialState: AuthState = {
+  user: null,
+  token: localStorage.getItem('authToken'),
+  status: 'idle'
+}
+
+export const login = createAsyncThunk(
+  'auth/login',
+  async (credentials: { email: string; password: string }) => {
+    const data = await apiLogin(credentials)
+    const token = data?.data?.token
+    if (token) localStorage.setItem('authToken', token)
+    return { user: data.data, token }
+  }
+)
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    logout(state) {
+      state.user = null
+      state.token = null
+      localStorage.removeItem('authToken')
+    }
+  },
+  extraReducers: builder => {
+    builder
+      .addCase(login.pending, state => {
+        state.status = 'loading'
+      })
+      .addCase(login.fulfilled, (state, action) => {
+        state.status = 'idle'
+        state.user = action.payload.user
+        state.token = action.payload.token
+      })
+      .addCase(login.rejected, state => {
+        state.status = 'failed'
+      })
+  }
+})
+
+export const { logout } = authSlice.actions
+export default authSlice.reducer

--- a/client/src/store/dealsSlice.ts
+++ b/client/src/store/dealsSlice.ts
@@ -1,0 +1,45 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { baseURL } from '../apiConfig'
+
+export interface Deal {
+  id: string
+  name: string
+}
+
+interface DealsState {
+  items: Deal[]
+  status: 'idle' | 'loading' | 'failed'
+}
+
+const initialState: DealsState = {
+  items: [],
+  status: 'idle'
+}
+
+export const fetchDeals = createAsyncThunk('deals/fetch', async () => {
+  const res = await fetch(`${baseURL}/deals`)
+  if (!res.ok) throw new Error('Failed to load deals')
+  const data = await res.json()
+  return data.data as Deal[]
+})
+
+const dealsSlice = createSlice({
+  name: 'deals',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchDeals.pending, state => {
+        state.status = 'loading'
+      })
+      .addCase(fetchDeals.fulfilled, (state, action) => {
+        state.status = 'idle'
+        state.items = action.payload
+      })
+      .addCase(fetchDeals.rejected, state => {
+        state.status = 'failed'
+      })
+  }
+})
+
+export default dealsSlice.reducer

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,0 +1,16 @@
+import { configureStore } from '@reduxjs/toolkit'
+import authReducer from './authSlice'
+import dealsReducer from './dealsSlice'
+import { useDispatch, TypedUseSelectorHook, useSelector } from 'react-redux'
+
+export const store = configureStore({
+  reducer: {
+    auth: authReducer,
+    deals: dealsReducer
+  }
+})
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch
+export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
     "<rootDir>/client/jest.config.js",
     "<rootDir>/server/jest.config.js",
   ],
+  verbose: true,
 };

--- a/tests/client/integration/loginDeals.test.tsx
+++ b/tests/client/integration/loginDeals.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import App from '../../../client/src/App'
+import { Provider } from '../../../client/src/components/ui/provider'
+
+beforeEach(() => {
+  jest.spyOn(global, 'fetch').mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ data: { token: 't', id: 1 } })
+    } as any)
+  )
+})
+
+afterEach(() => {
+  ;(global.fetch as jest.Mock).mockRestore()
+  localStorage.clear()
+})
+
+test('login flow and deals list', async () => {
+  ;(global.fetch as jest.Mock)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { token: 't', id: 1 } })
+    })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: [{ id: '1', name: 'D1' }] })
+    })
+
+  render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <Provider>
+        <App />
+      </Provider>
+    </MemoryRouter>
+  )
+
+  fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@test.com' } })
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pass' } })
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
+
+  await waitFor(() => {
+    expect(screen.getByText('D1')).toBeInTheDocument()
+  })
+})

--- a/tests/client/redux/authSlice.test.ts
+++ b/tests/client/redux/authSlice.test.ts
@@ -1,0 +1,19 @@
+import reducer, { login, logout } from '../../../client/src/store/authSlice'
+
+describe('authSlice', () => {
+  it('handles login lifecycle', () => {
+    const state = reducer(undefined, login.pending('', { email: '', password: '' }))
+    expect(state.status).toBe('loading')
+    const user = { id: '1' }
+    const next = reducer(state, login.fulfilled({ user, token: 't' }, '', { email: '', password: '' }))
+    expect(next.status).toBe('idle')
+    expect(next.user).toEqual(user)
+    expect(next.token).toBe('t')
+  })
+
+  it('handles logout', () => {
+    const state = reducer({ user: { id: 1 }, token: 't', status: 'idle' }, logout())
+    expect(state.user).toBeNull()
+    expect(state.token).toBeNull()
+  })
+})

--- a/tests/client/redux/dealsSlice.test.ts
+++ b/tests/client/redux/dealsSlice.test.ts
@@ -1,0 +1,14 @@
+import reducer, { fetchDeals } from '../../../client/src/store/dealsSlice'
+
+interface Deal { id: string; name: string }
+
+describe('dealsSlice', () => {
+  it('stores deals on success', () => {
+    const pending = reducer(undefined, fetchDeals.pending(''))
+    expect(pending.status).toBe('loading')
+    const deals: Deal[] = [{ id: '1', name: 'Test' }]
+    const next = reducer(pending, fetchDeals.fulfilled(deals, ''))
+    expect(next.items).toEqual(deals)
+    expect(next.status).toBe('idle')
+  })
+})


### PR DESCRIPTION
## Summary
- enable verbose Jest across projects
- add Redux store with auth and deals slices
- add Redux Provider to Chakra provider
- protect dashboard routes with PrivateRoute
- create DashboardDeals page with logout
- update Login to dispatch login thunk
- add Jest config for client
- add slice unit tests and integration test

## Testing
- `npm test` *(fails: ESLint couldn't find plugin)*