### PR TITLE
[VOLTA] fix JSX namespace error

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -25,6 +25,8 @@
     "tailwindcss": "^3.4.4",
     "postcss": "^8.4.38",
     "autoprefixer": "^10.4.19",
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.14",
     "@types/react-redux": "^7.1.25"
   },
   "browserslist": {

--- a/client/src/components/PrivateRoute.tsx
+++ b/client/src/components/PrivateRoute.tsx
@@ -1,8 +1,12 @@
-import React from 'react'
+import { ReactElement } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAppSelector } from '../store'
 
-export default function PrivateRoute({ children }: { children: JSX.Element }) {
+export interface PrivateRouteProps {
+  children: ReactElement
+}
+
+export default function PrivateRoute({ children }: PrivateRouteProps) {
   const token = useAppSelector(state => state.auth.token)
   return token ? children : <Navigate to="/login" replace />
 }


### PR DESCRIPTION
## Summary
- fix the JSX namespace error by importing `ReactElement`
- declare `PrivateRouteProps` for clarity
- include `@types/react` and `@types/react-dom` as dev dependencies

## Testing
- `npm test` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*