### PR TITLE
[VOLTA] add project endpoints

### DIFF
--- a/server/src/controllers/rest/ProjectController.ts
+++ b/server/src/controllers/rest/ProjectController.ts
@@ -1,0 +1,26 @@
+import { Controller, Inject } from "@tsed/di";
+import { BodyParams } from "@tsed/platform-params";
+import { Get, Post, Returns } from "@tsed/schema";
+import { ProjectModel } from "../../models/ProjectModel";
+import { ProjectService } from "../../services/ProjectService";
+import { SuccessArrayResult, SuccessResult } from "../../util/entities";
+
+@Controller("/projects")
+export class ProjectController {
+  @Inject()
+  private projectService: ProjectService;
+
+  @Get()
+  @(Returns(200, SuccessArrayResult).Of(ProjectModel))
+  public async getProjects() {
+    const projects = await this.projectService.getProjects();
+    return new SuccessArrayResult(projects, ProjectModel);
+  }
+
+  @Post()
+  @(Returns(200, SuccessResult).Of(ProjectModel))
+  public async createProject(@BodyParams() body: Partial<ProjectModel>) {
+    const project = await this.projectService.createProject(body);
+    return new SuccessResult(project, ProjectModel);
+  }
+}

--- a/server/src/controllers/rest/index.ts
+++ b/server/src/controllers/rest/index.ts
@@ -5,3 +5,4 @@
 export * from "./OrganizationController";
 export * from "./AuthenticationController";
 export * from "./AdminController";
+export * from "./ProjectController";

--- a/server/src/models/ProjectModel.ts
+++ b/server/src/models/ProjectModel.ts
@@ -1,0 +1,35 @@
+import { CollectionOf, Property } from "@tsed/schema";
+import { Model, ObjectID } from "@tsed/mongoose";
+
+@Model({ name: "project" })
+export class ProjectModel {
+  @ObjectID("id")
+  _id: string;
+
+  @Property()
+  homeowner: string;
+
+  @Property()
+  saleDate: string;
+
+  @CollectionOf(String)
+  products: string[];
+
+  @Property()
+  contractAmount: number;
+
+  @Property()
+  status: string;
+
+  @Property()
+  stage: string;
+
+  @Property()
+  duration: string;
+
+  @Property()
+  systemSize: string;
+
+  @Property()
+  assignedTo: string;
+}

--- a/server/src/services/ProjectService.ts
+++ b/server/src/services/ProjectService.ts
@@ -1,0 +1,16 @@
+import { Inject, Injectable } from "@tsed/di";
+import { MongooseModel } from "@tsed/mongoose";
+import { ProjectModel } from "../models/ProjectModel";
+
+@Injectable()
+export class ProjectService {
+  constructor(@Inject(ProjectModel) private projectModel: MongooseModel<ProjectModel>) {}
+
+  public async createProject(data: Partial<ProjectModel>) {
+    return await this.projectModel.create(data);
+  }
+
+  public async getProjects() {
+    return await this.projectModel.find();
+  }
+}

--- a/tests/server/controllers/ProjectController.test.ts
+++ b/tests/server/controllers/ProjectController.test.ts
@@ -1,0 +1,37 @@
+import { PlatformTest } from "@tsed/common";
+import SuperTest from "supertest";
+import { Server } from "../../server/src/Server";
+import { ProjectService } from "../../server/src/services/ProjectService";
+
+describe("ProjectController", () => {
+  let request: SuperTest.SuperTest<SuperTest.Test>;
+  let projectService: ProjectService;
+
+  beforeEach(PlatformTest.bootstrap(Server));
+  beforeEach(() => {
+    request = SuperTest(PlatformTest.callback());
+    projectService = PlatformTest.injector.get(ProjectService)!;
+  });
+
+  afterEach(PlatformTest.reset);
+
+  it("GET /projects returns projects", async () => {
+    const projects = [{ _id: "1", homeowner: "John" }] as any;
+    jest.spyOn(projectService, "getProjects").mockResolvedValue(projects);
+
+    const res = await request.get("/rest/projects").expect(200);
+
+    expect(res.body).toEqual({ success: true, data: projects });
+  });
+
+  it("POST /projects creates project", async () => {
+    const payload = { homeowner: "Jane" };
+    const created = { _id: "2", homeowner: "Jane" } as any;
+    jest.spyOn(projectService, "createProject").mockResolvedValue(created);
+
+    const res = await request.post("/rest/projects").send(payload).expect(200);
+
+    expect(projectService.createProject).toHaveBeenCalledWith(payload);
+    expect(res.body).toEqual({ success: true, data: created });
+  });
+});


### PR DESCRIPTION
## Summary
- add basic `ProjectModel`
- implement `ProjectService`
- add `ProjectController` with GET/POST routes
- export controller from rest index
- test project controller endpoints

## Testing
- `npm test` *(fails: ESLint couldn't find '@typescript-eslint/eslint-plugin')*