### PR TITLE
[VOLTA] Projects dashboard view

### DIFF
--- a/client/src/pages/DashboardDeals.tsx
+++ b/client/src/pages/DashboardDeals.tsx
@@ -1,19 +1,39 @@
-import React, { useEffect } from 'react'
-import { Box, Button, List, ListItem, Heading } from '@chakra-ui/react'
-import { fetchDeals } from '../store/dealsSlice'
+import React, { useEffect, useState } from 'react'
+import {
+  Box,
+  Button,
+  Heading,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Input,
+  HStack
+} from '@chakra-ui/react'
+import { fetchProjects, createProject } from '../store/projectsSlice'
 import { logout } from '../store/authSlice'
 import { useAppDispatch, useAppSelector } from '../store'
 
 const DashboardDeals: React.FC = () => {
   const dispatch = useAppDispatch()
-  const deals = useAppSelector(state => state.deals.items)
+  const projects = useAppSelector(state => state.projects.items)
+  const [homeowner, setHomeowner] = useState('')
 
   useEffect(() => {
-    dispatch(fetchDeals())
+    dispatch(fetchProjects())
   }, [dispatch])
 
   const handleLogout = () => {
     dispatch(logout())
+  }
+
+  const handleCreate = () => {
+    if (homeowner) {
+      dispatch(createProject({ homeowner }))
+      setHomeowner('')
+    }
   }
 
   return (
@@ -21,12 +41,35 @@ const DashboardDeals: React.FC = () => {
       <Button onClick={handleLogout} mb={4} colorScheme="red">
         Logout
       </Button>
-      <Heading size="md" mb={2}>Deals</Heading>
-      <List spacing={2}>
-        {deals.map(deal => (
-          <ListItem key={deal.id}>{deal.name}</ListItem>
-        ))}
-      </List>
+      <Heading size="md" mb={2}>Projects</Heading>
+      <HStack mb={4}>
+        <Input
+          placeholder="Homeowner"
+          value={homeowner}
+          onChange={e => setHomeowner(e.target.value)}
+        />
+        <Button onClick={handleCreate} colorScheme="teal">
+          Add
+        </Button>
+      </HStack>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Homeowner</Th>
+            <Th>Sale Date</Th>
+            <Th>Status</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {projects.map(p => (
+            <Tr key={p._id}>
+              <Td>{p.homeowner}</Td>
+              <Td>{p.saleDate}</Td>
+              <Td>{p.status}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
     </Box>
   )
 }

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,12 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit'
 import authReducer from './authSlice'
 import dealsReducer from './dealsSlice'
+import projectsReducer from './projectsSlice'
 import { useDispatch, TypedUseSelectorHook, useSelector } from 'react-redux'
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
-    deals: dealsReducer
+    deals: dealsReducer,
+    projects: projectsReducer
   }
 })
 

--- a/client/src/store/projectsSlice.ts
+++ b/client/src/store/projectsSlice.ts
@@ -1,0 +1,64 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { baseURL } from '../apiConfig'
+
+export interface Project {
+  _id?: string
+  homeowner?: string
+  saleDate?: string
+  status?: string
+}
+
+interface ProjectsState {
+  items: Project[]
+  status: 'idle' | 'loading' | 'failed'
+}
+
+const initialState: ProjectsState = {
+  items: [],
+  status: 'idle'
+}
+
+export const fetchProjects = createAsyncThunk('projects/fetch', async () => {
+  const res = await fetch(`${baseURL}/projects`)
+  if (!res.ok) throw new Error('Failed to load projects')
+  const data = await res.json()
+  return data.data as Project[]
+})
+
+export const createProject = createAsyncThunk(
+  'projects/create',
+  async (project: Partial<Project>) => {
+    const res = await fetch(`${baseURL}/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(project)
+    })
+    if (!res.ok) throw new Error('Failed to create project')
+    const data = await res.json()
+    return data.data as Project
+  }
+)
+
+const projectsSlice = createSlice({
+  name: 'projects',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchProjects.pending, state => {
+        state.status = 'loading'
+      })
+      .addCase(fetchProjects.fulfilled, (state, action) => {
+        state.status = 'idle'
+        state.items = action.payload
+      })
+      .addCase(fetchProjects.rejected, state => {
+        state.status = 'failed'
+      })
+      .addCase(createProject.fulfilled, (state, action) => {
+        state.items.push(action.payload)
+      })
+  }
+})
+
+export default projectsSlice.reducer

--- a/tests/client/integration/loginDeals.test.tsx
+++ b/tests/client/integration/loginDeals.test.tsx
@@ -17,7 +17,7 @@ afterEach(() => {
   localStorage.clear()
 })
 
-test('login flow and deals list', async () => {
+test('login flow and projects list', async () => {
   ;(global.fetch as jest.Mock)
     .mockResolvedValueOnce({
       ok: true,
@@ -25,7 +25,7 @@ test('login flow and deals list', async () => {
     })
     .mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ data: [{ id: '1', name: 'D1' }] })
+      json: () => Promise.resolve({ data: [{ _id: '1', homeowner: 'Jane' }] })
     })
 
   render(
@@ -41,6 +41,6 @@ test('login flow and deals list', async () => {
   fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
   await waitFor(() => {
-    expect(screen.getByText('D1')).toBeInTheDocument()
+    expect(screen.getByText('Jane')).toBeInTheDocument()
   })
 })

--- a/tests/client/redux/projectsSlice.test.ts
+++ b/tests/client/redux/projectsSlice.test.ts
@@ -1,0 +1,19 @@
+import reducer, { fetchProjects, createProject } from '../../../client/src/store/projectsSlice'
+
+describe('projectsSlice', () => {
+  it('stores projects on fetch', () => {
+    const pending = reducer(undefined, fetchProjects.pending(''))
+    expect(pending.status).toBe('loading')
+    const projects = [{ _id: '1', homeowner: 'Jane' }]
+    const next = reducer(pending, fetchProjects.fulfilled(projects, ''))
+    expect(next.items).toEqual(projects)
+    expect(next.status).toBe('idle')
+  })
+
+  it('adds project on create', () => {
+    const state = reducer(undefined, fetchProjects.fulfilled([], ''))
+    const project = { _id: '2', homeowner: 'John' }
+    const next = reducer(state, createProject.fulfilled(project, ''))
+    expect(next.items).toContain(project)
+  })
+})


### PR DESCRIPTION
## Summary
- add projects Redux slice
- register projects slice in the store
- render projects table with creation form on dashboard deals page
- test projects slice
- update login integration test to check projects

## Testing
- `npm test` *(fails: ESLint plugin missing)*