### PR TITLE
[VOLTA] Expand dashboard and CSV mapping

### DIFF
--- a/client/src/pages/DashboardDeals.tsx
+++ b/client/src/pages/DashboardDeals.tsx
@@ -95,7 +95,22 @@ const DashboardDeals: React.FC = () => {
             <Tr>
               <Th>Homeowner</Th>
               <Th>Sale Date</Th>
+              <Th>Products</Th>
               <Th>Status</Th>
+              <Th>Stage</Th>
+              <Th isNumeric>Contract Amount</Th>
+              <Th>System Size</Th>
+              <Th>Installer</Th>
+              <Th>Phone</Th>
+              <Th>Sales Rep</Th>
+              <Th>Address</Th>
+              <Th>Utility Company</Th>
+              <Th>PTO Status</Th>
+              <Th>Project Manager</Th>
+              <Th>Financing</Th>
+              <Th>Source</Th>
+              <Th>AHJ</Th>
+              <Th>QC Status</Th>
             </Tr>
           </Thead>
           <Tbody>
@@ -103,7 +118,22 @@ const DashboardDeals: React.FC = () => {
               <Tr key={p._id}>
                 <Td>{p.homeowner}</Td>
                 <Td>{p.saleDate}</Td>
+                <Td>{p.products?.join(', ')}</Td>
                 <Td>{p.status}</Td>
+                <Td>{p.stage}</Td>
+                <Td isNumeric>{p.contractAmount}</Td>
+                <Td>{p.systemSize}</Td>
+                <Td>{p.installer}</Td>
+                <Td>{p.phone}</Td>
+                <Td>{p.salesRep}</Td>
+                <Td>{p.address}</Td>
+                <Td>{p.utilityCompany}</Td>
+                <Td>{p.ptoStatus}</Td>
+                <Td>{p.projectManager}</Td>
+                <Td>{p.financing}</Td>
+                <Td>{p.source}</Td>
+                <Td>{p.ahj}</Td>
+                <Td>{p.qcStatus}</Td>
               </Tr>
             ))}
           </Tbody>

--- a/client/src/store/projectsSlice.ts
+++ b/client/src/store/projectsSlice.ts
@@ -11,6 +11,17 @@ export interface Project {
   stage?: string
   duration?: string
   systemSize?: string
+  phone?: string
+  address?: string
+  installer?: string
+  utilityCompany?: string
+  salesRep?: string
+  projectManager?: string
+  financing?: string
+  source?: string
+  ahj?: string
+  qcStatus?: string
+  ptoStatus?: string
   assignedTo?: string
 }
 

--- a/server/src/models/ProjectModel.ts
+++ b/server/src/models/ProjectModel.ts
@@ -31,5 +31,38 @@ export class ProjectModel {
   systemSize: string;
 
   @Property()
+  phone: string;
+
+  @Property()
+  address: string;
+
+  @Property()
+  installer: string;
+
+  @Property()
+  utilityCompany: string;
+
+  @Property()
+  salesRep: string;
+
+  @Property()
+  projectManager: string;
+
+  @Property()
+  financing: string;
+
+  @Property()
+  source: string;
+
+  @Property()
+  ahj: string;
+
+  @Property()
+  qcStatus: string;
+
+  @Property()
+  ptoStatus: string;
+
+  @Property()
   assignedTo: string;
 }

--- a/server/src/services/ProjectService.ts
+++ b/server/src/services/ProjectService.ts
@@ -20,12 +20,25 @@ export function transformCSVToProject(row: Record<string, string>): Partial<Proj
     homeowner: row['Homeowner'],
     saleDate: row['Sale Date'],
     products: row['Products'] ? row['Products'].split(';') : [],
-    contractAmount: parseFloat(row['Contract Amount']?.replace(/[^0-9.]/g, '') || '0'),
-    status: row['Solar Install - Status'],
+    status: row['Solar Install - Status'] || row['Status'],
     stage: row['Stage'],
-    duration: row['Project Duration'],
-    systemSize: row['Final System Size (Watts)'],
-    assignedTo: row['email1']?.toLowerCase() || null
+    contractAmount: parseFloat((row['Contract Amount Final'] || '').replace(/[^0-9.]/g, '')) || 0,
+    systemSize: row['Final System Size (Watts)'] || row['Sold System Size (Watts)'],
+
+    phone: row['Phone'],
+    address: row['Address'],
+    installer: row['Installer'],
+    utilityCompany: row['Utility Company Text'],
+    salesRep: row['Sales Rep'],
+    projectManager: row['Project Manager'],
+    financing: row['Financing'],
+    source: row['Source'],
+    ahj: row['AHJ'],
+    qcStatus: row['QC Check - Status'],
+    ptoStatus: row['PTO - Status'],
+
+    assignedTo: row['email1']?.toLowerCase() || null,
+    duration: row['Project Duration']
   };
 }
 

--- a/tests/server/services/ProjectService.test.ts
+++ b/tests/server/services/ProjectService.test.ts
@@ -12,11 +12,22 @@ describe('ProjectService csv helpers', () => {
       Homeowner: 'John',
       'Sale Date': '2024-01-01',
       Products: 'Panel;Battery',
-      'Contract Amount': '$100',
+      'Contract Amount Final': '$100',
       'Solar Install - Status': 'Open',
       Stage: 'Planning',
       'Project Duration': '6m',
       'Final System Size (Watts)': '5000',
+      Installer: 'Best Solar',
+      Phone: '555',
+      'Sales Rep': 'Sue',
+      Address: '123 St',
+      'Utility Company Text': 'PG&E',
+      'PTO - Status': 'In Progress',
+      'Project Manager': 'Bob',
+      Financing: 'Cash',
+      Source: 'Referral',
+      AHJ: 'City',
+      'QC Check - Status': 'Pending',
       email1: 'USER@TEST.COM'
     } as any;
     const proj = transformCSVToProject(row);
@@ -24,12 +35,25 @@ describe('ProjectService csv helpers', () => {
       homeowner: 'John',
       saleDate: '2024-01-01',
       products: ['Panel', 'Battery'],
-      contractAmount: 100,
       status: 'Open',
       stage: 'Planning',
-      duration: '6m',
+      contractAmount: 100,
       systemSize: '5000',
-      assignedTo: 'user@test.com'
+
+      phone: '555',
+      address: '123 St',
+      installer: 'Best Solar',
+      utilityCompany: 'PG&E',
+      salesRep: 'Sue',
+      projectManager: 'Bob',
+      financing: 'Cash',
+      source: 'Referral',
+      ahj: 'City',
+      qcStatus: 'Pending',
+      ptoStatus: 'In Progress',
+
+      assignedTo: 'user@test.com',
+      duration: '6m'
     });
   });
 });


### PR DESCRIPTION
## Summary
- display all project fields on Deals dashboard
- map CSV upload fields into `ProjectModel`
- store new project fields in Redux slice
- extend project model schema
- update CSV transform tests

## Testing
- `npm test` *(fails: ESLint couldn't find plugin @typescript-eslint/eslint-plugin)*