### PR TITLE
[VOLTA] Fix sticky layout

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -49,6 +49,11 @@ const Sidebar: React.FC = () => {
         p={4}
         w={collapsed ? '60px' : '200px'}
         display={{ base: 'none', md: 'block' }}
+        position="sticky"
+        top="0"
+        left="0"
+        className="h-screen overflow-y-auto"
+        flexShrink={0}
       >
         <IconButton
           aria-label="Toggle"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  overscroll-behavior: none;
+  touch-action: manipulation;
+}

--- a/client/src/pages/DashboardDeals.tsx
+++ b/client/src/pages/DashboardDeals.tsx
@@ -66,10 +66,25 @@ const DashboardDeals: React.FC = () => {
   }
 
   return (
-    <Flex>
+    <Flex className="h-screen overflow-hidden">
       <Sidebar />
-      <Box px={{ base: 4, md: 8 }} py={6} flex="1">
-      <Flex justify="space-between" align="center" mb={6}>
+      <Box
+        px={{ base: 4, md: 8 }}
+        py={6}
+        flex="1"
+        overflowY="auto"
+        className="min-w-0"
+      >
+      <Flex
+        justify="space-between"
+        align="center"
+        mb={6}
+        position="sticky"
+        top="0"
+        zIndex="10"
+        bg="white"
+        className="shadow-sm border-b py-3"
+      >
         <Heading fontSize={{ base: '2xl', md: '3xl' }}>Deals Dashboard</Heading>
         <HStack>
           <Button onClick={handleLogout} colorScheme="red" variant="outline">


### PR DESCRIPTION
## Summary
- make sidebar sticky with fixed height scrolling
- pin dashboard header while scrolling
- prevent overscroll with global CSS

## Testing
- `npm test` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*