### PR TITLE
[VOLTA] Import createProject in Dashboard Deals

### DIFF
--- a/client/src/pages/DashboardDeals.tsx
+++ b/client/src/pages/DashboardDeals.tsx
@@ -16,13 +16,12 @@ import {
   Stack
 } from '@chakra-ui/react'
 import { AddIcon } from '@chakra-ui/icons'
-import { fetchProjects } from '../store/projectsSlice'
+import { fetchProjects, createProject } from '../store/projectsSlice'
 import { logout } from '../store/authSlice'
 import { useAppDispatch, useAppSelector } from '../store'
 import AddProjectModal from '../components/AddProjectModal'
 import CSVPreviewModal, { CSVRow } from '../components/CSVPreviewModal'
 import Sidebar from '../components/Sidebar'
-import { baseURL } from '../apiConfig'
 import DealCard from '../components/DealCard'
 
 const DashboardDeals: React.FC = () => {


### PR DESCRIPTION
## Summary
- fix missing `createProject` import in DashboardDeals page

## Testing
- `npm test` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*