### PR TITLE
[VOLTA] Display username and role next to avatar

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Box, Button, Flex, Heading } from '@chakra-ui/react'
 import { AddIcon } from '@chakra-ui/icons'
+import UserAvatar from './UserAvatar'
 
 interface NavbarProps {
   onLogout: () => void
@@ -23,7 +24,7 @@ const Navbar: React.FC<NavbarProps> = ({ onLogout, onCSVChange, onAddProject }) 
         <Heading size="md" className="whitespace-nowrap">
           Volta CRM
         </Heading>
-        <Flex gap={2} flexWrap="wrap">
+        <Flex gap={2} flexWrap="wrap" align="center">
           <Button
             onClick={onLogout}
             colorScheme="red"
@@ -51,6 +52,7 @@ const Navbar: React.FC<NavbarProps> = ({ onLogout, onCSVChange, onAddProject }) 
           >
             Add Project
           </Button>
+          <UserAvatar />
         </Flex>
       </Flex>
     </Box>

--- a/client/src/components/UserAvatar.tsx
+++ b/client/src/components/UserAvatar.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Avatar, Box, Flex, Text, Tooltip } from '@chakra-ui/react'
+import { useAppSelector } from '../store'
+
+const UserAvatar: React.FC = () => {
+  const user = useAppSelector(state => state.auth.user)
+
+  if (!user) return null
+
+  return (
+    <Tooltip label={`${user.name} (${user.role})`} placement="left" hasArrow>
+      <Flex align="center" px={2} gap={2}>
+        <Avatar
+          name={user.name}
+          src={user.avatarUrl || 'https://api.dicebear.com/7.x/thumbs/svg?seed=voltauser'}
+          borderRadius="10px"
+          size="sm"
+        />
+        <Box lineHeight="short">
+          <Text fontSize="sm" className="font-semibold">
+            {user.name}
+          </Text>
+          <Text fontSize="xs" color="gray.500">
+            {user.role}
+          </Text>
+        </Box>
+      </Flex>
+    </Tooltip>
+  )
+}
+
+export default UserAvatar

--- a/tests/client/components/navbar/Navbar.test.tsx
+++ b/tests/client/components/navbar/Navbar.test.tsx
@@ -1,6 +1,22 @@
 import { render, screen } from '@testing-library/react'
 import Navbar from '../../../../client/src/components/Navbar'
 import { Provider } from '../../../../client/src/components/ui/provider'
+import { store } from '../../../../client/src/store'
+import { login, logout } from '../../../../client/src/store/authSlice'
+
+beforeEach(() => {
+  store.dispatch(
+    login.fulfilled(
+      { user: { name: 'Test User', email: 't@test.com', role: 'Admin' }, token: 't' },
+      '',
+      { email: '', password: '' }
+    )
+  )
+})
+
+afterEach(() => {
+  store.dispatch(logout())
+})
 
 describe('Navbar', () => {
   it('shows brand and action buttons', () => {
@@ -13,5 +29,8 @@ describe('Navbar', () => {
     expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /upload csv/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /add project/i })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: /test user/i })).toBeInTheDocument()
+    expect(screen.getByText(/Test User/i)).toBeInTheDocument()
+    expect(screen.getByText(/Admin/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- extend `UserAvatar` to show the logged in user's name and role
- update navbar test to expect name and role text

## Testing
- `npm test` *(fails: ESLint couldn't find plugin)*
- `npm run lint` in `client` *(fails: missing script)*
- `npm run test:lint` in `server` *(fails: plugin missing)*