### PR TITLE
[VOLTA] persist auth user across reloads

### DIFF
--- a/client/src/store/authSlice.ts
+++ b/client/src/store/authSlice.ts
@@ -7,8 +7,9 @@ interface AuthState {
   status: 'idle' | 'loading' | 'failed'
 }
 
+const storedUser = localStorage.getItem('authUser')
 const initialState: AuthState = {
-  user: null,
+  user: storedUser ? JSON.parse(storedUser) : null,
   token: localStorage.getItem('authToken'),
   status: 'idle'
 }
@@ -18,7 +19,6 @@ export const login = createAsyncThunk(
   async (credentials: { email: string; password: string }) => {
     const data = await apiLogin(credentials)
     const token = data?.data?.token
-    if (token) localStorage.setItem('authToken', token)
     return { user: data.data, token }
   }
 )
@@ -31,6 +31,7 @@ const authSlice = createSlice({
       state.user = null
       state.token = null
       localStorage.removeItem('authToken')
+      localStorage.removeItem('authUser')
     }
   },
   extraReducers: builder => {
@@ -42,6 +43,8 @@ const authSlice = createSlice({
         state.status = 'idle'
         state.user = action.payload.user
         state.token = action.payload.token
+        localStorage.setItem('authToken', action.payload.token ?? '')
+        localStorage.setItem('authUser', JSON.stringify(action.payload.user))
       })
       .addCase(login.rejected, state => {
         state.status = 'failed'

--- a/tests/client/redux/authSlice.test.ts
+++ b/tests/client/redux/authSlice.test.ts
@@ -1,5 +1,11 @@
 import reducer, { login, logout } from '../../../client/src/store/authSlice'
 
+beforeEach(() => {
+  window.localStorage.clear()
+  jest.spyOn(window.localStorage, 'setItem')
+  jest.spyOn(window.localStorage, 'removeItem')
+})
+
 describe('authSlice', () => {
   it('handles login lifecycle', () => {
     const state = reducer(undefined, login.pending('', { email: '', password: '' }))
@@ -9,11 +15,23 @@ describe('authSlice', () => {
     expect(next.status).toBe('idle')
     expect(next.user).toEqual(user)
     expect(next.token).toBe('t')
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('authToken', 't')
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('authUser', JSON.stringify(user))
+  })
+
+  it('initializes from localStorage', () => {
+    window.localStorage.setItem('authToken', 'tok')
+    window.localStorage.setItem('authUser', JSON.stringify({ id: 2 }))
+    const state = reducer(undefined, { type: 'init' } as any)
+    expect(state.token).toBe('tok')
+    expect(state.user).toEqual({ id: 2 })
   })
 
   it('handles logout', () => {
     const state = reducer({ user: { id: 1 }, token: 't', status: 'idle' }, logout())
     expect(state.user).toBeNull()
     expect(state.token).toBeNull()
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith('authToken')
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith('authUser')
   })
 })


### PR DESCRIPTION
## Summary
- persist `auth.user` in localStorage
- verify login persistence in `authSlice` tests

## Testing
- `npm test` *(fails: ESLint couldn't find the plugin `@typescript-eslint/eslint-plugin`)*