### PR TITLE
[VOLTA] Responsive sidebar and layout

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,65 +1,20 @@
 import React from 'react'
-import { Flex, Button, Heading } from '@chakra-ui/react'
-import { AddIcon } from '@chakra-ui/icons'
-import UserAvatar from './UserAvatar'
+import { Flex, Heading } from '@chakra-ui/react'
 
-interface NavbarProps {
-  onLogout: () => void
-  onCSVChange: (e: React.ChangeEvent<HTMLInputElement>) => void
-  onAddProject: () => void
-}
-
-const Navbar: React.FC<NavbarProps> = ({ onLogout, onCSVChange, onAddProject }) => {
-  const inputRef = React.useRef<HTMLInputElement | null>(null)
-
-  return (
-    <Flex
-      position="sticky"
-      top={0}
-      zIndex={50}
-      px={4}
-      py={2}
-      bg="white"
-      align="center"
-      justify="space-between"
-      wrap="wrap"
-      className="border-b shadow-sm"
-    >
-      <Heading size="md" mb={{ base: 2, md: 0 }}>
-        Volta CRM
-      </Heading>
-
-      <Flex
-        align="center"
-        gap={2}
-        wrap="wrap"
-        flexDirection={{ base: 'column', md: 'row' }}
-      >
-        <Button onClick={onLogout} colorScheme="red" variant="outline">
-          Logout
-        </Button>
-        <input
-          type="file"
-          accept=".csv"
-          onChange={onCSVChange}
-          hidden
-          ref={inputRef}
-          data-testid="csv-input"
-        />
-        <Button onClick={() => inputRef.current?.click()} variant="ghost">
-          Upload CSV
-        </Button>
-        <Button
-          leftIcon={<AddIcon />}
-          colorScheme="teal"
-          onClick={onAddProject}
-        >
-          Add Project
-        </Button>
-        <UserAvatar />
-      </Flex>
-    </Flex>
-  )
-}
+const Navbar: React.FC = () => (
+  <Flex
+    position="sticky"
+    top={0}
+    zIndex={50}
+    px={4}
+    py={2}
+    bg="white"
+    justify="start"
+    align="center"
+    boxShadow="sm"
+  >
+    <Heading size="md">Volta CRM</Heading>
+  </Flex>
+)
 
 export default Navbar

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -7,7 +7,7 @@ import { useAppSelector } from '../store'
 import SidebarItem from './SidebarItem'
 
 const Sidebar: React.FC = () => {
-  const [isSidebarOpen, setSidebarOpen] = React.useState(false)
+  const [isSidebarOpen, setSidebarOpen] = React.useState(true)
   const user = useAppSelector((state) => state.auth.user);
   const links = (
     <VStack align="start" spacing={3}>
@@ -55,20 +55,27 @@ const Sidebar: React.FC = () => {
       position="sticky"
       top={0}
       h="100vh"
-      width={{ base: isSidebarOpen ? '220px' : '64px', md: '220px' }}
-      transition="width 0.3s"
+      width={isSidebarOpen ? '220px' : '64px'}
+      transition="width 0.3s ease"
       bg="white"
       borderRight="1px solid #E2E8F0"
       flexShrink={0}
     >
       <IconButton
         aria-label="Toggle sidebar"
-        icon={<HamburgerIcon />}
+        icon={
+          <HamburgerIcon
+            transform={isSidebarOpen ? 'rotate(90deg)' : 'rotate(0deg)'}
+            transition="transform 0.3s"
+          />
+        }
         size="sm"
-        m={2}
+        mt={4}
+        ml={isSidebarOpen ? 3 : 1}
+        variant="ghost"
         onClick={() => setSidebarOpen(!isSidebarOpen)}
       />
-      <VStack spacing={4} align="stretch" px={isSidebarOpen ? 4 : 2} pt={4}>
+      <VStack spacing={4} align="stretch" px={isSidebarOpen ? 4 : 2} pt={6}>
         {links}
       </VStack>
     </Box>

--- a/client/src/components/SidebarItem.tsx
+++ b/client/src/components/SidebarItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { HStack, Icon, Text } from '@chakra-ui/react'
+import { HStack, Icon, Text, Tooltip } from '@chakra-ui/react'
 import { NavLink } from 'react-router-dom'
 
 interface SidebarItemProps {
@@ -11,10 +11,12 @@ interface SidebarItemProps {
 
 const SidebarItem: React.FC<SidebarItemProps> = ({ icon, label, to, isOpen }) => (
   <NavLink to={to}>
-    <HStack px={2} py={2} spacing={2} _hover={{ bg: 'gray.100' }}>
-      <Icon as={icon} boxSize={5} />
-      <Text display={{ base: isOpen ? 'block' : 'none', md: 'block' }}>{label}</Text>
-    </HStack>
+    <Tooltip label={label} isDisabled={isOpen} placement="right">
+      <HStack px={2} py={2} spacing={2} _hover={{ bg: 'gray.100' }}>
+        <Icon as={icon} boxSize={5} />
+        {isOpen && <Text>{label}</Text>}
+      </HStack>
+    </Tooltip>
   </NavLink>
 )
 

--- a/client/src/pages/DashboardDeals.tsx
+++ b/client/src/pages/DashboardDeals.tsx
@@ -14,6 +14,7 @@ import {
   useToast,
   Stack,
   Button,
+  HStack,
 } from "@chakra-ui/react";
 import { AddIcon } from "@chakra-ui/icons";
 import { fetchProjects, createProject } from "../store/projectsSlice";
@@ -21,7 +22,7 @@ import { logout } from "../store/authSlice";
 import { useAppDispatch, useAppSelector } from "../store";
 import AddProjectModal from "../components/AddProjectModal";
 import CSVPreviewModal from "../components/CSVPreviewModal";
-import CSVUploadDropzone from "../components/CSVUploadDropzone";
+import UserAvatar from "../components/UserAvatar";
 import { CSVRow, parseCSV } from "../utils/csv";
 import Sidebar from "../components/Sidebar";
 import Navbar from "../components/Navbar";
@@ -38,6 +39,7 @@ const DashboardDeals: React.FC = () => {
   } = useDisclosure();
   const [csvQueue, setCsvQueue] = useState<CSVRow[]>([]);
   const toast = useToast();
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     dispatch(fetchProjects());
@@ -103,11 +105,7 @@ const DashboardDeals: React.FC = () => {
 
   return (
     <Box overflowX="hidden" minH="100vh">
-      <Navbar
-        onLogout={handleLogout}
-        onCSVChange={handleUpload}
-        onAddProject={handleCreate}
-      />
+      <Navbar />
       <Flex className="overflow-x-hidden" pt={16}>
         <Sidebar />
         <Box
@@ -117,14 +115,35 @@ const DashboardDeals: React.FC = () => {
           overflowY="auto"
           className="min-w-0 overflow-x-hidden"
         >
-          <Heading
-            fontSize={{ base: "sm", md: "lg" }}
-            className="text-balance"
-            mb={6}
-          >
-            Deals Dashboard
-          </Heading>
-
+          <Flex justify="space-between" align="center" wrap="wrap" mb={4}>
+            <Heading size="md" className="text-balance">
+              Deals Dashboard
+            </Heading>
+            <HStack spacing={{ base: 2, md: 4 }} flexWrap="wrap">
+              <Button variant="outline" colorScheme="red" onClick={handleLogout}>
+                Logout
+              </Button>
+              <input
+                type="file"
+                accept=".csv"
+                onChange={handleUpload}
+                hidden
+                ref={inputRef}
+                data-testid="csv-input"
+              />
+              <Button onClick={() => inputRef.current?.click()} variant="ghost">
+                Upload CSV
+              </Button>
+              <Button
+                leftIcon={<AddIcon />}
+                colorScheme="teal"
+                onClick={handleCreate}
+              >
+                Add Project
+              </Button>
+              <UserAvatar />
+            </HStack>
+          </Flex>
           <Box height={4} />
 
           <Stack spacing={4} display={{ base: "block", md: "none" }}>


### PR DESCRIPTION
## Summary
- animate sidebar width toggle and tooltips on collapse
- simplify navbar to just branding
- move action buttons and avatar into Deals dashboard header

## Testing
- `npm run lint --workspace=client` *(fails: Missing script)*
- `npm run test:lint --workspace=server` *(fails: missing eslint plugin)*
- `npx --no-install jest --selectProjects=client` *(fails: network EHOSTUNREACH)*
- `npx --no-install jest --selectProjects=server` *(fails: network EHOSTUNREACH)*