### PR TITLE
[VOLTA] Dashboard routes via layout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,7 +4,10 @@ import LandingPage from './pages/Landing';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import UserManagementPage from './pages/UserManagementPage';
-import DashboardDeals from './pages/DashboardDeals';
+import ProjectsPage from './pages/ProjectsPage';
+import AccountsPayablePage from './pages/AccountsPayablePage';
+import TechnicianTasksPage from './pages/TechnicianTasksPage';
+import DashboardLayout from './components/DashboardLayout';
 import PrivateRoute from './components/PrivateRoute';
 
 const App: React.FC = () => {
@@ -14,23 +17,20 @@ const App: React.FC = () => {
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Register />} />
-        <Route path="/dashboard" element={<Navigate to="/dashboard/deals" />} />
         <Route
-          path="/dashboard/deals"
+          path="/dashboard"
           element={
             <PrivateRoute>
-              <DashboardDeals />
+              <DashboardLayout />
             </PrivateRoute>
           }
-        />
-        <Route
-          path="/users"
-          element={
-            <PrivateRoute>
-              <UserManagementPage />
-            </PrivateRoute>
-          }
-        />
+        >
+          <Route index element={<Navigate to="projects" replace />} />
+          <Route path="projects" element={<ProjectsPage />} />
+          <Route path="accounts" element={<AccountsPayablePage />} />
+          <Route path="users" element={<UserManagementPage />} />
+          <Route path="technician" element={<TechnicianTasksPage />} />
+        </Route>
         <Route path="*" element={<Navigate to="/" />} />
       </Routes>
     </Router>

--- a/client/src/__tests__/ProjectsPage.test.tsx
+++ b/client/src/__tests__/ProjectsPage.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import DashboardDeals from '../pages/DashboardDeals';
+import ProjectsPage from '../pages/ProjectsPage';
 import axios from 'axios';
 jest.mock('axios');
 import { Provider } from '../components/ui/provider';
 
-describe('DashboardDeals', () => {
+describe('ProjectsPage', () => {
   beforeEach(() => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -24,7 +24,7 @@ describe('DashboardDeals', () => {
   test('opens add project modal', () => {
     render(
       <Provider>
-        <DashboardDeals />
+        <ProjectsPage />
       </Provider>
     );
 
@@ -35,7 +35,7 @@ describe('DashboardDeals', () => {
   test('shows upload csv button', () => {
     render(
       <Provider>
-        <DashboardDeals />
+        <ProjectsPage />
       </Provider>
     );
 
@@ -45,7 +45,7 @@ describe('DashboardDeals', () => {
   test('opens preview modal after csv upload', async () => {
     render(
       <Provider>
-        <DashboardDeals />
+        <ProjectsPage />
       </Provider>
     )
 

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Box, Flex } from '@chakra-ui/react'
+import { Outlet } from 'react-router-dom'
+import Navbar from './Navbar'
+import Sidebar from './Sidebar'
+
+const DashboardLayout: React.FC = () => (
+  <Box overflowX="hidden" minH="100vh">
+    <Navbar />
+    <Flex pt={16} className="overflow-x-hidden">
+      <Sidebar />
+      <Box flex="1" px={{ base: 4, md: 8 }} py={6} overflowY="auto">
+        <Outlet />
+      </Box>
+    </Flex>
+  </Box>
+)
+
+export default DashboardLayout

--- a/client/src/components/ProjectCard.tsx
+++ b/client/src/components/ProjectCard.tsx
@@ -12,11 +12,11 @@ import {
 import { EditIcon } from '@chakra-ui/icons'
 import { Project } from '../store/projectsSlice'
 
-interface DealCardProps {
+interface ProjectCardProps {
   project: Project
 }
 
-const DealCard: React.FC<DealCardProps> = ({ project }) => {
+const ProjectCard: React.FC<ProjectCardProps> = ({ project }) => {
   return (
     <Box bg="white" rounded="lg" shadow="sm" p={4} className="space-y-2">
       <Stack direction="row" justify="space-between" align="center">
@@ -77,4 +77,4 @@ const DealCard: React.FC<DealCardProps> = ({ project }) => {
   )
 }
 
-export default DealCard
+export default ProjectCard

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,85 +1,66 @@
 import React from 'react'
 import { Box, IconButton, VStack } from '@chakra-ui/react'
 import { HamburgerIcon } from '@chakra-ui/icons'
-import { FiList, FiBriefcase, FiUsers, FiDollarSign } from 'react-icons/fi'
-import { NavLink } from 'react-router-dom'
+import { FiGrid, FiBriefcase, FiUsers, FiDollarSign, FiSettings } from 'react-icons/fi'
 import { useAppSelector } from '../store'
 import SidebarItem from './SidebarItem'
 
 const Sidebar: React.FC = () => {
-  const [isSidebarOpen, setSidebarOpen] = React.useState(true)
-  const user = useAppSelector((state) => state.auth.user);
-  const links = (
-    <VStack align="start" spacing={3}>
-      <SidebarItem
-        icon={FiList}
-        label="Deals"
-        to="/dashboard/deals"
-        isOpen={isSidebarOpen}
-      />
-      <SidebarItem
-        icon={FiBriefcase}
-        label="Projects"
-        to="/projects"
-        isOpen={isSidebarOpen}
-      />
-      {user?.role === 'Technician' && (
-        <SidebarItem
-          icon={FiList}
-          label="Technician Allocation"
-          to="/technician"
-          isOpen={isSidebarOpen}
-        />
-      )}
-      {user?.role === 'Admin' && (
-        <>
-          <SidebarItem
-            icon={FiDollarSign}
-            label="Accounts Payable"
-            to="/accounts"
-            isOpen={isSidebarOpen}
-          />
-          <SidebarItem
-            icon={FiUsers}
-            label="Users"
-            to="/users"
-            isOpen={isSidebarOpen}
-          />
-        </>
-      )}
-    </VStack>
-  )
+  const [isSidebarOpen, setSidebarOpen] = React.useState(false)
+  const user = useAppSelector((state) => state.auth.user)
 
   return (
     <Box
       position="sticky"
       top={0}
       h="100vh"
-      width={isSidebarOpen ? '220px' : '64px'}
-      transition="width 0.3s ease"
+      width={{ base: isSidebarOpen ? '220px' : '64px', md: '220px' }}
+      transition="width 0.3s"
       bg="white"
       borderRight="1px solid #E2E8F0"
       flexShrink={0}
     >
       <IconButton
         aria-label="Toggle sidebar"
-        icon={
-          <HamburgerIcon
-            transform={isSidebarOpen ? 'rotate(90deg)' : 'rotate(0deg)'}
-            transition="transform 0.3s"
-          />
-        }
+        icon={<HamburgerIcon />}
         size="sm"
-        mt={4}
-        ml={isSidebarOpen ? 3 : 1}
-        variant="ghost"
+        m={2}
         onClick={() => setSidebarOpen(!isSidebarOpen)}
       />
-      <VStack spacing={4} align="stretch" px={isSidebarOpen ? 4 : 2} pt={6}>
-        {links}
+      <VStack spacing={4} align="stretch" px={isSidebarOpen ? 4 : 2} pt={4}>
+        <SidebarItem
+          icon={FiGrid}
+          label="Projects"
+          to="/dashboard/projects"
+          isOpen={isSidebarOpen}
+        />
+        {user?.role === 'Technician' && (
+          <SidebarItem
+            icon={FiSettings}
+            label="Technician Allocation"
+            to="/dashboard/technician"
+            isOpen={isSidebarOpen}
+          />
+        )}
+        {user?.role === 'Admin' && (
+          <>
+            <SidebarItem
+              icon={FiDollarSign}
+              label="Accounts Payable"
+              to="/dashboard/accounts"
+              isOpen={isSidebarOpen}
+            />
+            <SidebarItem
+              icon={FiUsers}
+              label="Users"
+              to="/dashboard/users"
+              isOpen={isSidebarOpen}
+            />
+          </>
+        )}
       </VStack>
     </Box>
   )
-};
+}
 
-export default Sidebar;
+export default Sidebar

--- a/client/src/pages/AccountsPayablePage.tsx
+++ b/client/src/pages/AccountsPayablePage.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Heading } from '@chakra-ui/react'
+
+const AccountsPayablePage: React.FC = () => (
+  <Heading size="md">Accounts Payable</Heading>
+)
+
+export default AccountsPayablePage

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -24,11 +24,9 @@ import AddProjectModal from "../components/AddProjectModal";
 import CSVPreviewModal from "../components/CSVPreviewModal";
 import UserAvatar from "../components/UserAvatar";
 import { CSVRow, parseCSV } from "../utils/csv";
-import Sidebar from "../components/Sidebar";
-import Navbar from "../components/Navbar";
-import DealCard from "../components/DealCard";
+import ProjectCard from "../components/ProjectCard";
 
-const DashboardDeals: React.FC = () => {
+const ProjectsPage: React.FC = () => {
   const dispatch = useAppDispatch();
   const projects = useAppSelector((state) => state.projects.items);
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -104,20 +102,10 @@ const DashboardDeals: React.FC = () => {
   };
 
   return (
-    <Box overflowX="hidden" minH="100vh">
-      <Navbar />
-      <Flex className="overflow-x-hidden" pt={16}>
-        <Sidebar />
-        <Box
-          px={{ base: 4, md: 8 }}
-          py={6}
-          flex="1"
-          overflowY="auto"
-          className="min-w-0 overflow-x-hidden"
-        >
+    <Box px={{ base: 4, md: 8 }} py={6} flex="1" overflowY="auto">
           <Flex justify="space-between" align="center" wrap="wrap" mb={4}>
-            <Heading size="md" className="text-balance">
-              Deals Dashboard
+          <Heading size="md" className="text-balance">
+              Projects Dashboard
             </Heading>
             <HStack spacing={{ base: 2, md: 4 }} flexWrap="wrap">
               <Button variant="outline" colorScheme="red" onClick={handleLogout}>
@@ -148,7 +136,7 @@ const DashboardDeals: React.FC = () => {
 
           <Stack spacing={4} display={{ base: "block", md: "none" }}>
             {projects.map((p) => (
-              <DealCard key={p._id} project={p} />
+              <ProjectCard key={p._id} project={p} />
             ))}
           </Stack>
 
@@ -261,9 +249,8 @@ const DashboardDeals: React.FC = () => {
             onConfirm={handleConfirm}
           />
         </Box>
-      </Flex>
     </Box>
   );
 };
 
-export default DashboardDeals;
+export default ProjectsPage;

--- a/client/src/pages/TechnicianTasksPage.tsx
+++ b/client/src/pages/TechnicianTasksPage.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Heading } from '@chakra-ui/react'
+
+const TechnicianTasksPage: React.FC = () => (
+  <Heading size="md">Technician Tasks</Heading>
+)
+
+export default TechnicianTasksPage


### PR DESCRIPTION
## Summary
- add `DashboardLayout` with `<Outlet />`
- rename Deals dashboard to `ProjectsPage`
- update `Sidebar` links to `/dashboard/*`
- hook new layout in `App`
- create placeholder pages for accounts and technician
- rename `DealCard` -> `ProjectCard` and update tests

## Testing
- `npm test` *(fails: ESLint couldn't find plugin)*