### PR TITLE
[VOLTA] fix login redirect and sidebar test

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -15,7 +15,7 @@ const LoginPage: React.FC = () => {
   const [error, setError] = useState('')
 
   useEffect(() => {
-    if (token) navigate('/dashboard/deals', { replace: true })
+    if (token) navigate('/dashboard/projects', { replace: true })
   }, [token, navigate])
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/tests/client/components/sidebar/Sidebar.test.tsx
+++ b/tests/client/components/sidebar/Sidebar.test.tsx
@@ -25,8 +25,8 @@ describe('Sidebar', () => {
         <Sidebar />
       </Provider>
     )
-    expect(screen.getByText(/Deals/i)).toBeInTheDocument()
     expect(screen.getByText(/Projects/i)).toBeInTheDocument()
+    expect(screen.getByText(/Accounts Payable/i)).toBeInTheDocument()
     expect(screen.getByText(/Users/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- fix login redirect path to `/dashboard/projects`
- update sidebar test for new labels

## Testing
- `npm test` *(fails: eslint plugin missing)*