### PR TITLE
[VOLTA] Invite email validation improvements

### DIFF
--- a/server/src/Server.ts
+++ b/server/src/Server.ts
@@ -28,6 +28,7 @@ import multer from "multer";
   disableComponentsScan: true,
   mount: {
     "/rest": [...Object.values(rest)],
+    "/api": [...Object.values(rest)],
     "/": [...Object.values(pages)]
   },
   swagger: [

--- a/tests/server/controllers/AdminController.test.ts
+++ b/tests/server/controllers/AdminController.test.ts
@@ -16,4 +16,12 @@ describe("AdminController /users/me", () => {
     const res = await request.get("/rest/users/me").expect(401);
     expect(res.body.status).toBe(401);
   });
+
+  it("GET /api/users/check-email returns status", async () => {
+    const res = await request
+      .get("/api/users/check-email")
+      .query({ email: "new@test.com" })
+      .expect(200);
+    expect(res.body).toEqual({ exists: false, invited: false });
+  });
 });


### PR DESCRIPTION
## Summary
- validate invite emails against current users and pending invites
- mount API endpoints under `/api`
- use `/api/users` routes in UserManagement page
- show detailed validation messages in the invite modal
- add controller test for `/api/users/check-email`

## Testing
- `npm test` *(fails: missing eslint plugin)*
- `npm --workspace client run lint` *(fails: missing script)*
- `npx jest --selectProjects=server tests/server/controllers/AdminController.test.ts --runInBand` *(fails: EHOSTUNREACH)*