### PR TITLE
[VOLTA] implement users slice via redux

### DIFF
--- a/client/src/pages/UserManagementPage.tsx
+++ b/client/src/pages/UserManagementPage.tsx
@@ -32,17 +32,12 @@ import {
 import { DeleteIcon, CheckIcon, WarningIcon, CloseIcon } from '@chakra-ui/icons';
 import CSVPreviewModal from '../components/CSVPreviewModal';
 import { parseCSV, CSVRow } from '../utils/csv';
-
-interface User {
-  id: string;
-  name: string;
-  email: string;
-  role: string;
-  phone?: string;
-}
+import { useAppDispatch, useAppSelector } from '../store';
+import { fetchUsers } from '../store/usersSlice';
 
 const UserManagementPage: React.FC = () => {
-  const [users, setUsers] = useState<User[]>([]);
+  const dispatch = useAppDispatch();
+  const users = useAppSelector(state => state.users.items);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [role, setRole] = useState('');
@@ -75,11 +70,6 @@ const UserManagementPage: React.FC = () => {
       });
   }, [email]);
 
-  const fetchUsers = async () => {
-    const res = await fetch('/api/users');
-    const json = await res.json();
-    setUsers(json.data || []);
-  };
 
   const onSubmitInvite = async () => {
     await fetch('/api/users/invite', {
@@ -93,7 +83,7 @@ const UserManagementPage: React.FC = () => {
     setEmail('');
     setRole('');
     setPhone('');
-    fetchUsers();
+    dispatch(fetchUsers());
   };
 
   const handleCsvUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -115,12 +105,12 @@ const UserManagementPage: React.FC = () => {
     ));
     closeCsv();
     setCsvUsers([]);
-    fetchUsers();
+    dispatch(fetchUsers());
   };
 
   useEffect(() => {
-    fetchUsers();
-  }, []);
+    dispatch(fetchUsers());
+  }, [dispatch]);
 
   return (
     <div className="p-4">

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -2,13 +2,15 @@ import { configureStore } from '@reduxjs/toolkit'
 import authReducer from './authSlice'
 import dealsReducer from './dealsSlice'
 import projectsReducer from './projectsSlice'
+import usersReducer from './usersSlice'
 import { useDispatch, TypedUseSelectorHook, useSelector } from 'react-redux'
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     deals: dealsReducer,
-    projects: projectsReducer
+    projects: projectsReducer,
+    users: usersReducer
   }
 })
 

--- a/client/src/store/usersSlice.ts
+++ b/client/src/store/usersSlice.ts
@@ -1,0 +1,50 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { baseURL } from '../apiConfig'
+
+export interface User {
+  _id?: string
+  name: string
+  email: string
+  role: string
+  phone?: string
+  isSuperAdmin?: boolean
+  createdAt?: string
+}
+
+interface UsersState {
+  items: User[]
+  status: 'idle' | 'loading' | 'failed'
+}
+
+const initialState: UsersState = {
+  items: [],
+  status: 'idle'
+}
+
+export const fetchUsers = createAsyncThunk('users/fetch', async () => {
+  const res = await fetch(`${baseURL}/users`)
+  if (!res.ok) throw new Error('Failed to load users')
+  const data = await res.json()
+  return data.data as User[]
+})
+
+const usersSlice = createSlice({
+  name: 'users',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchUsers.pending, state => {
+        state.status = 'loading'
+      })
+      .addCase(fetchUsers.fulfilled, (state, action) => {
+        state.status = 'idle'
+        state.items = action.payload
+      })
+      .addCase(fetchUsers.rejected, state => {
+        state.status = 'failed'
+      })
+  }
+})
+
+export default usersSlice.reducer

--- a/tests/client/redux/usersSlice.test.ts
+++ b/tests/client/redux/usersSlice.test.ts
@@ -1,0 +1,14 @@
+import reducer, { fetchUsers } from '../../../client/src/store/usersSlice'
+
+interface User { _id?: string; name: string; email: string; role: string }
+
+describe('usersSlice', () => {
+  it('stores users on fetch', () => {
+    const pending = reducer(undefined, fetchUsers.pending(''))
+    expect(pending.status).toBe('loading')
+    const users: User[] = [{ _id: '1', name: 'Alice', email: 'a@test.com', role: 'Admin' }]
+    const next = reducer(pending, fetchUsers.fulfilled(users, ''))
+    expect(next.items).toEqual(users)
+    expect(next.status).toBe('idle')
+  })
+})


### PR DESCRIPTION
## Summary
- fetch `/users` with a Redux slice mirroring projects
- connect users reducer to the store
- use Redux state in `UserManagementPage`
- add regression tests for the new slice

## Testing
- `npm run lint` (fails: Missing script)
- `npm run test:lint` in server (fails: missing ESLint plugin)
- `npm test` (fails: missing dependencies)
