### PR TITLE
[VOLTA] move users fetching to dedicated controller

### DIFF
--- a/server/src/controllers/rest/AdminController.ts
+++ b/server/src/controllers/rest/AdminController.ts
@@ -5,7 +5,7 @@ import { Enum, Get, Post, Property, Put, Required, Returns } from "@tsed/schema"
 import { AdminResultModel, AdminRoleModel, SaleRefResultModel, SuccessMessageModel } from "../../models/RestModels";
 import { AdminService } from "../../services/AdminService";
 import { NodemailerClient } from "../../clients/nodemailer";
-import { SuccessArrayResult, SuccessResult } from "../../util/entities";
+import { SuccessResult } from "../../util/entities";
 import { ADMIN } from "../../util/constants";
 import { EMAIL_EXISTS } from "../../util/errors";
 import { RoleEnum } from "../../../types";
@@ -31,29 +31,6 @@ export class AdminController {
   @Inject() private adminService: AdminService;
   @Inject() private saleRepService: SaleRepService;
 
-  @Get()
-  @(Returns(200, SuccessArrayResult).Of(AdminResultModel))
-  public async getAllUsers(@BodyParams() body: { orgId: string }, @Context() context: Context) {
-    await this.adminService.checkPermissions({ hasRole: [ADMIN] }, context.get("user"));
-    const admins = await this.adminService.findAdmins();
-    const response = {
-      admins: admins.map((admin) => {
-        return {
-          id: admin._id,
-          name: admin.name,
-          email: admin.email,
-          role: admin.role || "",
-          docs: admin.docs || "",
-          unlocked: admin.unlocked || "",
-          twoFactorEnabled: admin.twoFactorEnabled,
-          orgId: admin.orgId || "",
-          company: "Voltaic LLC",
-          isSuperAdmin: admin.isSuperAdmin
-        };
-      })
-    };
-    return new SuccessArrayResult(response.admins, AdminResultModel);
-  }
 
   @Put()
   @(Returns(200, SuccessResult).Of(AdminResultModel))

--- a/server/src/controllers/rest/UsersController.ts
+++ b/server/src/controllers/rest/UsersController.ts
@@ -1,0 +1,20 @@
+import { Controller, Inject } from "@tsed/di";
+import { Context } from "@tsed/platform-params";
+import { Get, Returns } from "@tsed/schema";
+import { UserService } from "../../services/UserService";
+import { AdminResultModel } from "../../models/RestModels";
+import { SuccessArrayResult } from "../../util/entities";
+
+@Controller("/users")
+export class UsersController {
+  @Inject()
+  private userService: UserService;
+
+  @Get("/")
+  @(Returns(200, SuccessArrayResult).Of(AdminResultModel))
+  async getAll(@Context() ctx: Context) {
+    const user = ctx.get("user");
+    const users = await this.userService.findAll(user);
+    return new SuccessArrayResult(users, AdminResultModel);
+  }
+}

--- a/server/src/controllers/rest/index.ts
+++ b/server/src/controllers/rest/index.ts
@@ -6,3 +6,4 @@ export * from "./OrganizationController";
 export * from "./AuthenticationController";
 export * from "./AdminController";
 export * from "./ProjectController";
+export * from "./UsersController";

--- a/server/src/services/UserService.ts
+++ b/server/src/services/UserService.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable } from "@tsed/di";
+import { Unauthorized } from "@tsed/exceptions";
+import { MongooseModel } from "@tsed/mongoose";
+import { AdminModel } from "../models/AdminModel";
+import { JWTPayload } from "../../types";
+
+@Injectable()
+export class UserService {
+  constructor(@Inject(AdminModel) private userModel: MongooseModel<AdminModel>) {}
+
+  async findAll(user: JWTPayload) {
+    if (user?.role !== "Admin") {
+      throw new Unauthorized("Access denied");
+    }
+    return this.userModel.find();
+  }
+}

--- a/tests/server/controllers/UsersController.test.ts
+++ b/tests/server/controllers/UsersController.test.ts
@@ -1,0 +1,26 @@
+import { PlatformTest } from "@tsed/common";
+import SuperTest from "supertest";
+import { Server } from "../../server/src/Server";
+import { UserService } from "../../server/src/services/UserService";
+
+describe("UsersController", () => {
+  let request: SuperTest.SuperTest<SuperTest.Test>;
+  let userService: UserService;
+
+  beforeEach(PlatformTest.bootstrap(Server));
+  beforeEach(() => {
+    request = SuperTest(PlatformTest.callback());
+    userService = PlatformTest.injector.get(UserService)!;
+  });
+
+  afterEach(PlatformTest.reset);
+
+  it("GET /users returns users", async () => {
+    const users = [{ _id: "1", name: "Alice" }] as any;
+    jest.spyOn(userService, "findAll").mockResolvedValue(users);
+
+    const res = await request.get("/rest/users").expect(200);
+
+    expect(res.body).toEqual({ success: true, data: users });
+  });
+});


### PR DESCRIPTION
## Summary
- add UsersController and UserService to handle `/rest/users`
- simplify AdminController and export new controller
- add test coverage for UsersController

## Testing
- `npm test` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*