### PR TITLE
[VOLTA] Fix user retrieval in UserService

### DIFF
--- a/server/src/services/UserService.ts
+++ b/server/src/services/UserService.ts
@@ -9,10 +9,8 @@ import { JWTPayload } from "../../types";
 export class UserService {
   constructor(@Inject(AdminModel) private userModel: MongooseModel<AdminModel>) {}
 
-  async findAll(user: JWTPayload) {
-
-    if (user?.role !== "Admin") {
-
+  async findAll(user?: JWTPayload) {
+    if (!user || user.role !== "Admin") {
       throw new Unauthorized("Access denied");
     }
     return this.userModel.find();

--- a/tests/server/services/UserService.test.ts
+++ b/tests/server/services/UserService.test.ts
@@ -1,0 +1,33 @@
+import { UserService } from '../../../server/src/services/UserService';
+import { Unauthorized } from '@tsed/exceptions';
+
+describe('UserService', () => {
+  let userModel: any;
+  let service: UserService;
+
+  beforeEach(() => {
+    userModel = {
+      find: jest.fn()
+    };
+    // cast as any for constructor
+    service = new UserService(userModel as any);
+  });
+
+  it('throws when user is missing', async () => {
+    await expect(service.findAll(undefined as any)).rejects.toBeInstanceOf(Unauthorized);
+  });
+
+  it('throws when user is not admin', async () => {
+    const payload = { id: '1', email: 'a@test.com', role: 'User' } as any;
+    await expect(service.findAll(payload)).rejects.toBeInstanceOf(Unauthorized);
+  });
+
+  it('returns users when admin', async () => {
+    const users = [{ id: '1', name: 'Alice' }];
+    userModel.find.mockResolvedValue(users);
+    const payload = { id: '1', email: 'a@test.com', role: 'Admin' } as any;
+    const result = await service.findAll(payload);
+    expect(userModel.find).toHaveBeenCalled();
+    expect(result).toBe(users);
+  });
+});


### PR DESCRIPTION
## Summary
- handle undefined user in `UserService.findAll`
- add unit tests for `UserService`

## Testing
- `npm test` *(fails: ESLint plugin missing)*
- `npx jest --selectProjects=client` *(fails: network unreachable)*
- `npm run lint` in client *(fails: missing script)*
- `npm run test:lint` in server *(fails: ESLint plugin missing)*