### PR TITLE
[VOLTA] align role check for user service

### DIFF
--- a/server/src/services/UserService.ts
+++ b/server/src/services/UserService.ts
@@ -3,6 +3,7 @@ import { Unauthorized } from "@tsed/exceptions";
 import { MongooseModel } from "@tsed/mongoose";
 import { AdminModel } from "../models/AdminModel";
 import { JWTPayload } from "../../types";
+import { ADMIN } from "../util/constants";
 
 
 @Injectable()
@@ -10,7 +11,8 @@ export class UserService {
   constructor(@Inject(AdminModel) private userModel: MongooseModel<AdminModel>) {}
 
   async findAll(user?: JWTPayload) {
-    if (!user || user.role !== "Admin") {
+    const role = user?.role;
+    if (!role || (role !== ADMIN && role.toLowerCase() !== "admin")) {
       throw new Unauthorized("Access denied");
     }
     return this.userModel.find();

--- a/tests/server/services/UserService.test.ts
+++ b/tests/server/services/UserService.test.ts
@@ -1,5 +1,6 @@
 import { UserService } from '../../../server/src/services/UserService';
 import { Unauthorized } from '@tsed/exceptions';
+import { ADMIN } from '../../../server/src/util/constants';
 
 describe('UserService', () => {
   let userModel: any;
@@ -25,7 +26,7 @@ describe('UserService', () => {
   it('returns users when admin', async () => {
     const users = [{ id: '1', name: 'Alice' }];
     userModel.find.mockResolvedValue(users);
-    const payload = { id: '1', email: 'a@test.com', role: 'Admin' } as any;
+    const payload = { id: '1', email: 'a@test.com', role: ADMIN } as any;
     const result = await service.findAll(payload);
     expect(userModel.find).toHaveBeenCalled();
     expect(result).toBe(users);


### PR DESCRIPTION
## Summary
- broaden Admin role check to accept various admin role labels
- update UserService tests to use ADMIN constant

## Testing
- `npm test` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*