### PR TITLE
[VOLTA] align users fetch with projects

### DIFF
--- a/server/src/models/RestModels.ts
+++ b/server/src/models/RestModels.ts
@@ -1,4 +1,5 @@
 import { ArrayOf, Enum, Property, Required } from "@tsed/schema";
+import { Model } from "@tsed/mongoose";
 import { SocialAction } from "../../types";
 import { CategoryFieldType } from "./CategoryModel";
 
@@ -39,19 +40,14 @@ export class AdminProfileResultModel {
   @Property() public readonly imageUrl: string;
   @Property() public readonly verifyStatus: string;
 }
+@Model()
 export class AdminResultModel {
-  @Property() public readonly id: string;
-  @Property() public readonly name: string;
-  @Property() public readonly role: string;
-  @Property() public readonly docs: string;
-  @Property() public readonly company: string;
-  @Property() public readonly email: string;
-  @Property() public readonly recordID: string;
-  @Property() public readonly unlocked: string;
-  @Property() public readonly twoFactorEnabled: boolean;
-  @Property() public readonly orgId: string;
-  @Property() public token: string;
-  @Property() public readonly isSuperAdmin: boolean;
+  @Property() _id: string;
+  @Property() name: string;
+  @Property() email: string;
+  @Property() role: string;
+  @Property() phone?: string;
+  @Property() createdAt?: Date;
 }
 
 export class OrganizationResultModel {

--- a/server/src/services/UserService.ts
+++ b/server/src/services/UserService.ts
@@ -15,6 +15,6 @@ export class UserService {
     if (!role || (role !== ADMIN && role.toLowerCase() !== "admin")) {
       throw new Unauthorized("Access denied");
     }
-    return this.userModel.find();
+    return this.userModel.find().sort({ createdAt: -1 });
   }
 }

--- a/tests/server/services/UserService.test.ts
+++ b/tests/server/services/UserService.test.ts
@@ -5,11 +5,13 @@ import { ADMIN } from '../../../server/src/util/constants';
 describe('UserService', () => {
   let userModel: any;
   let service: UserService;
+  let sortMock: jest.Mock;
 
   beforeEach(() => {
+    sortMock = jest.fn();
     userModel = {
-      find: jest.fn()
-    };
+      find: jest.fn().mockReturnValue({ sort: sortMock })
+    } as any;
     // cast as any for constructor
     service = new UserService(userModel as any);
   });
@@ -25,10 +27,11 @@ describe('UserService', () => {
 
   it('returns users when admin', async () => {
     const users = [{ id: '1', name: 'Alice' }];
-    userModel.find.mockResolvedValue(users);
+    sortMock.mockResolvedValue(users);
     const payload = { id: '1', email: 'a@test.com', role: ADMIN } as any;
     const result = await service.findAll(payload);
     expect(userModel.find).toHaveBeenCalled();
+    expect(sortMock).toHaveBeenCalledWith({ createdAt: -1 });
     expect(result).toBe(users);
   });
 });


### PR DESCRIPTION
## Summary
- ensure AdminResultModel matches users collection
- return sorted results in UserService
- update UserService tests

## Testing
- `npm test` *(fails: ESLint plugin missing)*