### PR TITLE
[VOLTA] restrict dashboard access to admins

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,15 +1,17 @@
 import React from 'react'
 import { Box, IconButton, VStack, HStack, Icon, Text } from '@chakra-ui/react'
 import { HamburgerIcon } from '@chakra-ui/icons'
-import { FiGrid, FiBriefcase, FiUsers, FiDollarSign, FiSettings, FiLogOut } from 'react-icons/fi'
+import { FiGrid, FiUsers, FiDollarSign, FiLogOut } from 'react-icons/fi'
 import { useAppDispatch, useAppSelector } from '../store'
 import { logout } from '../store/authSlice'
 import SidebarItem from './SidebarItem'
 
 const Sidebar: React.FC = () => {
   const [isSidebarOpen, setSidebarOpen] = React.useState(false)
-  const user = useAppSelector((state) => state.auth.user)
+  const user = useAppSelector(state => state.auth.user)
   const dispatch = useAppDispatch()
+
+  if (!user || user.role !== 'Admin') return null
 
   return (
     <Box
@@ -38,14 +40,6 @@ const Sidebar: React.FC = () => {
           to="/dashboard/projects"
           isOpen={isSidebarOpen}
         />
-        {user?.role === 'Technician' && (
-          <SidebarItem
-            icon={FiSettings}
-            label="Technician Allocation"
-            to="/dashboard/technician"
-            isOpen={isSidebarOpen}
-          />
-        )}
         {user?.role === 'Admin' && (
           <>
             <SidebarItem

--- a/client/src/components/UserAvatar.tsx
+++ b/client/src/components/UserAvatar.tsx
@@ -3,9 +3,19 @@ import { Avatar, Box, Flex, Text, Tooltip } from "@chakra-ui/react";
 import { useAppSelector } from "../store";
 
 const UserAvatar: React.FC = () => {
-  const user = useAppSelector((state) => state.auth.user);
+  const user = useAppSelector(state => state.auth.user);
 
-  if (!user) return <p>Loading...</p>;
+  if (!user) {
+    return (
+      <Flex align="center" px={2} gap={2}>
+        <Avatar size="sm" />
+        <Box display={{ base: 'none', md: 'block' }}>
+          <Text fontWeight="medium">Loading...</Text>
+          <Text fontSize="xs" color="gray.500">&nbsp;</Text>
+        </Box>
+      </Flex>
+    );
+  }
 
   return (
     <Tooltip label={`${user.name} (${user.role})`} placement="left" hasArrow>
@@ -14,18 +24,14 @@ const UserAvatar: React.FC = () => {
           name={user.name}
           src={
             user.avatarUrl ||
-            "https://api.dicebear.com/7.x/thumbs/svg?seed=voltauser"
+            'https://api.dicebear.com/7.x/thumbs/svg?seed=voltauser'
           }
           borderRadius="10px"
           size="sm"
         />
         <Box lineHeight="short" display={{ base: 'none', md: 'block' }}>
-          <Text fontSize="sm" className="font-semibold">
-            {user.name}
-          </Text>
-          <Text fontSize="xs" color="gray.500">
-            {user.role}
-          </Text>
+          <Text fontWeight="medium">{user.name || 'N/A'}</Text>
+          <Text fontSize="xs" color="gray.500">{user.role || 'N/A'}</Text>
         </Box>
       </Flex>
     </Tooltip>

--- a/client/src/pages/DashboardDeals.tsx
+++ b/client/src/pages/DashboardDeals.tsx
@@ -22,7 +22,6 @@ import { logout } from "../store/authSlice";
 import { useAppDispatch, useAppSelector } from "../store";
 import AddProjectModal from "../components/AddProjectModal";
 import CSVPreviewModal from "../components/CSVPreviewModal";
-import UserAvatar from "../components/UserAvatar";
 import { CSVRow, parseCSV } from "../utils/csv";
 import Sidebar from "../components/Sidebar";
 import Navbar from "../components/Navbar";
@@ -145,7 +144,6 @@ const DashboardDeals: React.FC = () => {
               >
                 Add Project
               </Button>
-              <UserAvatar />
             </HStack>
           </Flex>
           <Box height={4} />

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -8,29 +8,29 @@ import ProjectsPage from './pages/ProjectsPage';
 import AccountsPayablePage from './pages/AccountsPayablePage';
 import TechnicianTasksPage from './pages/TechnicianTasksPage';
 import DashboardLayout from './components/DashboardLayout';
-import PrivateRoute from './components/PrivateRoute';
+import { useAppSelector } from './store';
 
-const AppRoutes: React.FC = () => (
-  <Routes>
-    <Route path="/" element={<LandingPage />} />
-    <Route path="/login" element={<Login />} />
-    <Route path="/register" element={<Register />} />
-    <Route
-      path="/dashboard"
-      element={
-        <PrivateRoute>
-          <DashboardLayout />
-        </PrivateRoute>
-      }
-    >
-      <Route index element={<Navigate to="projects" replace />} />
-      <Route path="projects" element={<ProjectsPage />} />
-      <Route path="accounts" element={<AccountsPayablePage />} />
-      <Route path="users" element={<UserManagementPage />} />
-      <Route path="technician" element={<TechnicianTasksPage />} />
-    </Route>
-    <Route path="*" element={<Navigate to="/" />} />
-  </Routes>
-);
+const AppRoutes: React.FC = () => {
+  const user = useAppSelector(state => state.auth.user);
+
+  return (
+    <Routes>
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/login" element={<Login />} />
+      <Route path="/register" element={<Register />} />
+      <Route
+        path="/dashboard/*"
+        element={
+          user?.role === 'Admin' ? (
+            <DashboardLayout />
+          ) : (
+            <Navigate to="/login" />
+          )
+        }
+      />
+      <Route path="*" element={<Navigate to="/" />} />
+    </Routes>
+  );
+};
 
 export default AppRoutes;


### PR DESCRIPTION
## Summary
- show user's name and role in UserAvatar
- hide sidebar unless role is Admin
- protect `/dashboard/*` routes by user role
- keep avatar only in Navbar

## Testing
- `npm test` *(fails: ESLint couldn't find plugin @typescript-eslint/eslint-plugin)*