### PR TITLE
[VOLTA] fix zindex and add sidebar toggle

### DIFF
--- a/client/src/__tests__/Navbar.test.tsx
+++ b/client/src/__tests__/Navbar.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Navbar from '../components/Navbar'
+import { Provider } from '../components/ui/provider'
+
+it('renders sidebar toggle button', () => {
+  render(
+    <Provider>
+      <Navbar onToggleSidebar={() => {}} toggleRef={React.createRef()} />
+    </Provider>
+  )
+  expect(screen.getByRole('button', { name: /toggle sidebar/i })).toBeInTheDocument()
+})

--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -6,19 +6,30 @@ import Sidebar from './Sidebar'
 
 const DashboardLayout: React.FC = () => {
   const [isSidebarOpen, setSidebarOpen] = React.useState(true)
+  const toggleRef = React.useRef<HTMLButtonElement>(null)
+
   const bg = useColorModeValue('white', 'gray.800')
   const text = useColorModeValue('gray.800', 'white')
+
+  const handleToggle = () => setSidebarOpen((open) => !open)
+  const handleClose = () => {
+    setSidebarOpen(false)
+    toggleRef.current?.focus()
+  }
+
   return (
     <Flex
       h="100vh"
       overflow="hidden"
       bg={bg}
       color={text}
-      transition="background 0.2s, color 0.2s, width 0.2s"
+      transition="background 0.2s, color 0.2s"
     >
-      {isSidebarOpen && <Sidebar isOpen={isSidebarOpen} onClose={() => setSidebarOpen(false)} />}
-      <Box flex="1" transition="width 0.2s">
-        <Navbar />
+      {isSidebarOpen && (
+        <Sidebar isOpen={isSidebarOpen} onClose={handleClose} toggleRef={toggleRef} />
+      )}
+      <Box flex="1">
+        <Navbar onToggleSidebar={handleToggle} toggleRef={toggleRef} />
         <Box flex="1" overflowY="auto" bg={bg} transition="background 0.2s, color 0.2s">
           <Box px={{ base: 4, md: 8 }} py={6}>
             <Outlet />

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -1,25 +1,41 @@
 import React from 'react'
-import { Flex, Heading, useColorModeValue } from '@chakra-ui/react'
+import { Flex, Heading, IconButton, useColorModeValue } from '@chakra-ui/react'
+import { FiMenu } from 'react-icons/fi'
 import UserAvatar from './UserAvatar'
 
-const Navbar: React.FC = () => {
+interface NavbarProps {
+  onToggleSidebar: () => void
+  toggleRef: React.RefObject<HTMLButtonElement>
+}
+const Navbar: React.FC<NavbarProps> = ({ onToggleSidebar, toggleRef }) => {
   const bg = useColorModeValue('white', 'gray.800')
   const text = useColorModeValue('gray.800', 'white')
+  const borderColor = useColorModeValue('gray.200', 'gray.700')
   return (
     <Flex
       position="sticky"
       top={0}
-      zIndex={50}
+      zIndex="sticky"
       px={4}
       py={2}
       bg={bg}
       color={text}
       justify="space-between"
       align="center"
-      boxShadow="sm"
+      borderBottom="1px solid"
+      borderColor={borderColor}
       transition="background 0.2s, color 0.2s"
     >
-      <Heading size="md">Volta CRM</Heading>
+      <Flex align="center" gap={2}>
+        <IconButton
+          ref={toggleRef}
+          aria-label="Toggle sidebar"
+          icon={<FiMenu />}
+          variant="ghost"
+          onClick={onToggleSidebar}
+        />
+        <Heading size="md">Volta CRM</Heading>
+      </Flex>
       <UserAvatar />
     </Flex>
   )

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Drawer,
   DrawerOverlay,
   DrawerContent,
+  Slide,
 } from "@chakra-ui/react";
 import {
   FiGrid,
@@ -25,14 +26,20 @@ import ThemeToggle from "./ThemeToggle";
 interface SidebarProps {
   isOpen?: boolean;
   onClose?: () => void;
+  toggleRef?: React.RefObject<HTMLButtonElement>;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ isOpen = true, onClose }) => {
+const Sidebar: React.FC<SidebarProps> = ({ isOpen = true, onClose, toggleRef }) => {
   const user = useAppSelector((state) => state.auth.user)
   const dispatch = useAppDispatch()
   const bg = useColorModeValue('white', 'gray.800')
   const borderColor = useColorModeValue('gray.200', 'gray.700')
   const hoverBg = useColorModeValue('gray.100', 'gray.700')
+
+  const handleClose = () => {
+    onClose?.()
+    toggleRef?.current?.focus()
+  }
 
   const content = (
     <Box
@@ -82,15 +89,25 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen = true, onClose }) => {
 
   return (
     <>
+      {/* Mobile drawer */}
       {isOpen && (
-        <Drawer isOpen={isOpen} placement="left" onClose={onClose}>
+        <Drawer
+          isOpen={isOpen}
+          placement="left"
+          onClose={handleClose}
+          finalFocusRef={toggleRef}
+        >
           <DrawerOverlay />
           <DrawerContent>{content}</DrawerContent>
         </Drawer>
       )}
-      <Box display={{ base: 'none', md: 'flex' }} position="sticky" top={0} h="100vh" flexShrink={0}>
-        {content}
-      </Box>
+
+      {/* Desktop slide */}
+      <Slide direction="left" in={isOpen} style={{ zIndex: 20 }} unmountOnExit>
+        <Box display={{ base: 'none', md: 'block' }} h="100vh" flexShrink={0}>
+          {content}
+        </Box>
+      </Slide>
     </>
   )
 };


### PR DESCRIPTION
## Summary
- keep sidebar state in the layout and pass handlers
- move sidebar toggle into the navbar
- animate the sidebar and manage focus when closed
- test that the navbar exposes the toggle button

## Testing
- `npm test` *(fails: ESLint plugin missing)*
- `npx jest --selectProjects=client` *(fails: cannot reach npm registry)*
- `npm run lint` *(no script)*