### PR TITLE
[VOLTA] Refine table spacing and sidebar

### DIFF
--- a/client/src/components/DataTable.tsx
+++ b/client/src/components/DataTable.tsx
@@ -33,61 +33,79 @@ function DataTable<T>({
   const totalPages = Math.ceil(total / pageSize);
 
   return (
-    <div className="w-full h-full max-h-screen overflow-auto">
+    <div className="w-full h-full">
       <div className="hidden md:block">
-        <table className={`${fontClass} w-full`}>
-          <thead className="bg-gray-100 sticky top-0 z-10">
-            <tr>
-              {columns.map((col) => (
-                <th key={col.key} className="text-left p-2">
-                  {col.header}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {data.map((item, rowIdx) => (
-              <tr key={rowIdx} className="even:bg-gray-50">
+        <div className="w-full h-full max-h-[calc(100vh-4rem)] overflow-auto">
+          <table className={`${fontClass} leading-tight w-full`}>
+            <thead className="bg-gray-200 dark:bg-gray-800 sticky top-0 z-10">
+              <tr>
                 {columns.map((col) => (
-                  <td key={col.key} className="p-2">
-                    {col.renderCell ? col.renderCell(item) : (item as any)[col.key]}
-                  </td>
+                  <th key={col.key} className="text-left p-1">
+                    {col.header}
+                  </th>
                 ))}
               </tr>
-            ))}
-          </tbody>
-          <tfoot>
-            <tr>
-              <td colSpan={columns.length} className="p-0">
-                <div className="flex items-center justify-end p-2 border-t">
-                  <label className="mr-2">Rows</label>
-                  <select
-                    value={pageSize}
-                    onChange={(e) => onPageSizeChange(+e.target.value)}
-                    className="border rounded p-1"
-                  >
-                    {[10, 20, 50, 100].map((n) => (
-                      <option key={n} value={n}>
-                        {n}
-                      </option>
-                    ))}
-                  </select>
-                  <span className="ml-4">
-                    Page {page} of {totalPages}
-                  </span>
-                </div>
-              </td>
-            </tr>
-          </tfoot>
-        </table>
-      </div>
-      {renderMobileRow && (
-        <div className="md:hidden">
-          {data.map((item, idx) => (
-            <React.Fragment key={idx}>{renderMobileRow(item)}</React.Fragment>
-          ))}
+            </thead>
+            <tbody>
+              {data.map((item, rowIdx) => (
+                <tr key={rowIdx} className="border-b bg-white dark:bg-gray-800">
+                  {columns.map((col) => (
+                    <td key={col.key} className="p-1">
+                      {col.renderCell ? col.renderCell(item) : (item as any)[col.key]}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colSpan={columns.length} className="p-0">
+                  <div className="flex items-center justify-end p-2 border-t bg-white dark:bg-gray-900">
+                    <label className="mr-2">Rows</label>
+                    <select
+                      value={pageSize}
+                      onChange={(e) => onPageSizeChange(+e.target.value)}
+                      className="border rounded p-1"
+                    >
+                      {[10, 20, 50, 100].map((n) => (
+                        <option key={n} value={n}>
+                          {n}
+                        </option>
+                      ))}
+                    </select>
+                    <span className="ml-4">
+                      Page {page} of {totalPages}
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            </tfoot>
+          </table>
         </div>
-      )}
+      </div>
+      <div className="md:hidden flex flex-col items-center">
+        {data.map((item, idx) => (
+          <div
+            key={idx}
+            className="max-w-md w-full mx-auto bg-white dark:bg-gray-700 rounded-lg p-4 shadow mb-4"
+          >
+            {renderMobileRow ? (
+              renderMobileRow(item)
+            ) : (
+              <dl className="grid grid-cols-2 gap-1 text-sm">
+                {columns.map((col) => (
+                  <React.Fragment key={col.key}>
+                    <dt className="font-medium">{col.header}</dt>
+                    <dd>
+                      {col.renderCell ? col.renderCell(item) : (item as any)[col.key]}
+                    </dd>
+                  </React.Fragment>
+                ))}
+              </dl>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/client/src/components/SidebarItem.tsx
+++ b/client/src/components/SidebarItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { HStack, Icon, Text, Tooltip } from '@chakra-ui/react'
 import { NavLink } from 'react-router-dom'
+import { useLayout } from './Layout'
 
 interface SidebarItemProps {
   icon: React.ElementType
@@ -9,16 +10,23 @@ interface SidebarItemProps {
   isOpen: boolean
   onNavigate?: () => void
 }
+const SidebarItem: React.FC<SidebarItemProps> = ({ icon, label, to, isOpen, onNavigate }) => {
+  const { closeSidebar } = useLayout()
+  const handleClick = () => {
+    closeSidebar()
+    onNavigate?.()
+  }
 
-const SidebarItem: React.FC<SidebarItemProps> = ({ icon, label, to, isOpen, onNavigate }) => (
-  <NavLink to={to} onClick={onNavigate}>
-    <Tooltip label={label} isDisabled={isOpen} placement="right">
-      <HStack px={2} py={2} spacing={2} _hover={{ bg: 'gray.100' }}>
-        <Icon as={icon} boxSize={5} />
-        {isOpen && <Text>{label}</Text>}
-      </HStack>
-    </Tooltip>
-  </NavLink>
-)
+  return (
+    <NavLink to={to} onClick={handleClick}>
+      <Tooltip label={label} isDisabled={isOpen} placement="right">
+        <HStack px={2} py={2} spacing={2} _hover={{ bg: 'gray.100' }}>
+          <Icon as={icon} boxSize={5} />
+          {isOpen && <Text>{label}</Text>}
+        </HStack>
+      </Tooltip>
+    </NavLink>
+  )
+}
 
 export default SidebarItem


### PR DESCRIPTION
## Summary
- shrink DataTable paddings, add internal scrolling
- render mobile cards with consistent layout
- auto-close sidebar when navigating links

## Testing
- `npm test` *(fails: ESLint plugin missing)*