### PR TITLE
[VOLTA] Center project cards on mobile

### DIFF
--- a/client/src/components/DataTable.tsx
+++ b/client/src/components/DataTable.tsx
@@ -95,7 +95,7 @@ function DataTable<T>({
         </div>
       </div>
       {renderMobileRow && (
-        <div className="md:hidden flex flex-col items-center bg-white dark:bg-gray-800">
+        <div className="md:hidden flex flex-col items-center px-4">
           {data.map((item, idx) => (
             <div
               key={idx}

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -141,7 +141,7 @@ const ProjectsPage: React.FC = () => {
       </Flex>
       <Box height={4} />
 
-      <div className="w-full h-full">
+      <div className="w-full h-full px-4 md:px-0">
         <DataTable
           columns={columns}
           data={projects}


### PR DESCRIPTION
## Summary
- apply flex wrapper with padding to DataTable mobile rows
- pad ProjectsPage table container so cards center

## Testing
- `npm test` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*