### PR TITLE
[VOLTA] Scrollable DataTable layout fixes

### DIFF
--- a/client/src/components/DataTable.tsx
+++ b/client/src/components/DataTable.tsx
@@ -55,18 +55,19 @@ function DataTable<T>({
 
   return (
     <div className="flex flex-col space-y-4">
-      <div className="flex justify-between items-center">
+      <div className="flex justify-start mb-4">
         <input
           type="text"
           placeholder="Search..."
-          className="w-full max-w-sm p-2 border border-gray-300 rounded-lg focus:ring-indigo-500 focus:border-indigo-500"
+          className="w-full md:w-1/2 lg:w-1/3 p-2 border border-gray-300 rounded-lg focus:ring-indigo-500 focus:border-indigo-500"
           value={query}
           onChange={handleSearch}
         />
       </div>
-      <div className="overflow-x-auto w-full">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+      <div className="w-full overflow-x-auto">
+        <div className="inline-block min-w-max">
+          <table className="min-w-max divide-y divide-gray-200">
+            <thead className="sticky top-0 bg-gray-50">
             <tr>
               {columns.map((col) => (
                 <th
@@ -95,6 +96,7 @@ function DataTable<T>({
             ))}
           </tbody>
         </table>
+      </div>
       </div>
       <div className="flex items-center justify-between py-3">
         <div>

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -95,7 +95,8 @@ const ProjectsPage: React.FC = () => {
   ];
 
   return (
-    <div className="flex-1 p-6 bg-gray-50 dark:bg-gray-800 overflow-auto">
+    <div className="flex-1 px-4 md:px-6 bg-gray-50 dark:bg-gray-800 overflow-auto">
+      <div className="w-full max-w-screen-xl mx-auto">
       <div className="flex flex-wrap justify-between items-center mb-6">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
           Projects Dashboard
@@ -144,6 +145,7 @@ const ProjectsPage: React.FC = () => {
         rows={csvQueue}
         onConfirm={handleConfirm}
       />
+      </div>
     </div>
   );
 };

--- a/client/src/pages/UserManagementPage.tsx
+++ b/client/src/pages/UserManagementPage.tsx
@@ -97,7 +97,8 @@ const UserManagementPage: React.FC = () => {
   }, [dispatch]);
 
   return (
-    <div className="flex-1 p-6 bg-gray-50 dark:bg-gray-800 overflow-auto">
+    <div className="flex-1 px-4 md:px-6 bg-gray-50 dark:bg-gray-800 overflow-auto">
+      <div className="w-full max-w-screen-xl mx-auto">
       <div className="flex flex-wrap justify-between items-center mb-6">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
           Users
@@ -231,6 +232,7 @@ const UserManagementPage: React.FC = () => {
         rows={csvUsers}
         onConfirm={confirmCsv}
       />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- make DataTable horizontally scrollable with sticky header
- align page content flush left and adjust padding
- resize search bar responsively

## Testing
- `npm test` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*