### PR TITLE
[VOLTA] Scrollable and centered data tables

### DIFF
--- a/client/src/components/DataTable.tsx
+++ b/client/src/components/DataTable.tsx
@@ -64,39 +64,36 @@ function DataTable<T>({
           onChange={handleSearch}
         />
       </div>
-      <div className="w-full overflow-x-auto">
-        <div className="inline-block min-w-max">
-          <table className="min-w-max divide-y divide-gray-200">
-            <thead className="sticky top-0 bg-gray-50">
-            <tr>
-              {columns.map((col) => (
-                <th
-                  key={col.key}
-                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                >
-                  {col.header}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {pageData.map((item, idx) => (
-              <tr key={idx} className="hover:bg-gray-100">
-                {columns.map((col) => (
-                  <td
-                    key={col.key}
-                    className="px-6 py-4 whitespace-nowrap text-sm text-gray-900"
-                  >
-                    {col.renderCell
-                      ? col.renderCell(item)
-                      : (item as any)[col.key]}
-                  </td>
+      <div className="flex flex-col overflow-y-auto h-full">
+        <div className="w-full overflow-x-auto">
+          <div className="inline-block min-w-max">
+            <table className="min-w-full bg-white border border-gray-200">
+              <thead className="sticky top-0 z-10 bg-gray-50 text-xs text-gray-700 uppercase h-6 transition-all ease-in-out">
+                <tr>
+                  {columns.map((col) => (
+                    <th key={col.key} className="px-2 2xl:px-6 py-3 bg-gray-200">
+                      {col.header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="select-none">
+                {pageData.map((item, idx) => (
+                  <tr key={idx} className="border-b">
+                    {columns.map((col) => (
+                      <td
+                        key={col.key}
+                        className="px-6 py-1.5 whitespace-nowrap text-sm text-gray-900"
+                      >
+                        {col.renderCell ? col.renderCell(item) : (item as any)[col.key]}
+                      </td>
+                    ))}
+                  </tr>
                 ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
       <div className="flex items-center justify-between py-3">
         <div>

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -128,7 +128,7 @@ const ProjectsPage: React.FC = () => {
       </div>
       <div className="h-4" />
 
-      <div className="w-full h-full">
+      <div className="w-full max-w-screen-xl mx-auto px-4 md:px-6">
         <DataTable
           columns={columns}
           data={projects}

--- a/client/src/pages/UserManagementPage.tsx
+++ b/client/src/pages/UserManagementPage.tsx
@@ -129,7 +129,7 @@ const UserManagementPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="w-full h-full">
+      <div className="w-full max-w-screen-xl mx-auto px-4 md:px-6">
         <DataTable
           columns={columns}
           data={users}


### PR DESCRIPTION
## Summary
- style `<DataTable>` with Tailwind scrollable container and sticky header
- center tables in `UserManagementPage` and `ProjectsPage`

## Testing
- `npm test` *(fails: could not run eslint plugin)*
- `npx jest --selectProjects=client --ci --runInBand` *(fails: EHOSTUNREACH)*
- `npx jest --selectProjects=server --ci --runInBand` *(fails: EHOSTUNREACH)*
- `npm run lint` in `client` *(fails: missing script)*
- `npm run test:lint` in `server` *(fails: missing eslint plugin)*