### PR TITLE
[VOLTA] Adjust layout heights for table pages

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -28,7 +28,7 @@ const Layout: React.FC = () => {
         )}
         <div className="flex-1 flex flex-col">
           <Navbar onToggleSidebar={toggleSidebar} toggleRef={toggleRef} />
-          <div className="flex-1 px-4 md:px-6 bg-gray-50 dark:bg-gray-800 overflow-auto">
+          <div className="flex-1 flex flex-col overflow-hidden px-4 md:px-6 bg-gray-50 dark:bg-gray-800">
             <Outlet />
           </div>
         </div>

--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -96,7 +96,7 @@ const ProjectsPage: React.FC = () => {
 
   return (
 
-    <div className="flex-1 px-4 md:px-6 bg-gray-50 dark:bg-gray-800 overflow-auto">
+    <div className="flex-1 flex flex-col h-full px-4 md:px-6 bg-gray-50 dark:bg-gray-800">
 
       <div className="w-full max-w-screen-xl mx-auto">
       <div className="flex flex-wrap justify-between items-center mb-6">
@@ -128,7 +128,7 @@ const ProjectsPage: React.FC = () => {
       </div>
       <div className="h-4" />
 
-      <div className="w-full max-w-screen-xl mx-auto px-4 md:px-6">
+      <div className="flex-1 w-full max-w-screen-xl mx-auto px-4 md:px-6">
         <DataTable
           columns={columns}
           data={projects}

--- a/client/src/pages/UserManagementPage.tsx
+++ b/client/src/pages/UserManagementPage.tsx
@@ -98,7 +98,7 @@ const UserManagementPage: React.FC = () => {
 
   return (
 
-    <div className="flex-1 px-4 md:px-6 bg-gray-50 dark:bg-gray-800 overflow-auto">
+    <div className="flex-1 flex flex-col h-full px-4 md:px-6 bg-gray-50 dark:bg-gray-800">
 
       <div className="w-full max-w-screen-xl mx-auto">
       <div className="flex flex-wrap justify-between items-center mb-6">
@@ -129,7 +129,7 @@ const UserManagementPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="w-full max-w-screen-xl mx-auto px-4 md:px-6">
+      <div className="flex-1 w-full max-w-screen-xl mx-auto px-4 md:px-6">
         <DataTable
           columns={columns}
           data={users}


### PR DESCRIPTION
## Summary
- make layout wrapper a flex container with overflow-hidden
- allow project and user management pages to fill available height

## Testing
- `npm test` *(fails: ESLint plugin missing)*