### PR TITLE
[VOLTA] Fix mobile scroll in user management layout

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -28,7 +28,7 @@ const Layout: React.FC = () => {
         )}
         <div className="flex-1 flex flex-col">
           <Navbar onToggleSidebar={toggleSidebar} toggleRef={toggleRef} />
-          <div className="flex-1 flex flex-col overflow-hidden px-4 md:px-6 bg-gray-50 dark:bg-gray-800">
+          <div className="flex-1 flex flex-col overflow-y-auto overflow-x-hidden px-4 md:px-6 bg-gray-50 dark:bg-gray-800">
             <Outlet />
           </div>
         </div>

--- a/tests/client/components/layout/Layout.test.tsx
+++ b/tests/client/components/layout/Layout.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import Layout from '../../../../client/src/components/Layout';
+import { Provider } from '../../../../client/src/components/ui/provider';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+describe('Layout', () => {
+  it('renders container with vertical scroll classes', () => {
+    const { container } = render(
+      <Provider>
+        <MemoryRouter initialEntries={["/dashboard"]}>
+          <Routes>
+            <Route path="/dashboard" element={<Layout />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    );
+    const scrollDiv = container.querySelector('div.overflow-y-auto');
+    expect(scrollDiv).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- fix overflow on main content area so mobile pages scroll
- add a regression test for the layout scroll behavior

## Testing
- `npm test` *(fails: ESLint couldn't find the plugin `@typescript-eslint/eslint-plugin`)*