### PR TITLE
[VOLTA] implement accounts payable endpoints

### DIFF
--- a/server/src/controllers/rest/AccountsPayableController.ts
+++ b/server/src/controllers/rest/AccountsPayableController.ts
@@ -1,0 +1,36 @@
+import { Controller, Inject } from "@tsed/di";
+import { BodyParams, PathParams, QueryParams } from "@tsed/common";
+import { Get, Post, Patch, Returns } from "@tsed/schema";
+import { AccountsPayableService } from "../../services/AccountsPayableService";
+import { AccountsPayableModel } from "../../models/AccountsPayableModel";
+import { SuccessArrayResult, SuccessResult } from "../../util/entities";
+
+@Controller("/accounts-payable")
+export class AccountsPayableController {
+  @Inject()
+  private service: AccountsPayableService;
+
+  @Get()
+  @(Returns(200, SuccessArrayResult).Of(AccountsPayableModel))
+  async list(@QueryParams("paid") paid: string = "false") {
+    const results = await this.service.listByPaidStatus(paid === "true");
+    return new SuccessArrayResult(results, AccountsPayableModel);
+  }
+
+  @Post("/projects/:projectId")
+  @(Returns(200, SuccessArrayResult).Of(AccountsPayableModel))
+  async upsert(
+    @PathParams("projectId") projectId: string,
+    @BodyParams("allocations") allocations: { technicianId: string; percentage: number }[]
+  ) {
+    const res = await this.service.upsertAllocations(projectId, allocations);
+    return new SuccessArrayResult(res, AccountsPayableModel);
+  }
+
+  @Patch(":id/pay")
+  @(Returns(200, SuccessResult).Of(AccountsPayableModel))
+  async markPaid(@PathParams("id") id: string) {
+    const result = await this.service.markPaid(id);
+    return new SuccessResult(result, AccountsPayableModel);
+  }
+}

--- a/server/src/controllers/rest/index.ts
+++ b/server/src/controllers/rest/index.ts
@@ -7,3 +7,4 @@ export * from "./AuthenticationController";
 export * from "./AdminController";
 export * from "./ProjectController";
 export * from "./UsersController";
+export * from "./AccountsPayableController";

--- a/server/src/models/AccountsPayableModel.ts
+++ b/server/src/models/AccountsPayableModel.ts
@@ -1,0 +1,43 @@
+import { Model, ObjectID, Ref } from "@tsed/mongoose";
+import { Default, Property } from "@tsed/schema";
+import { AdminModel } from "./AdminModel";
+import { ProjectModel } from "./ProjectModel";
+
+@Model({ name: "accountsPayable" })
+export class AccountsPayableModel {
+  @ObjectID("id")
+  _id: string;
+
+  @Property()
+  technicianId: string;
+
+  @Property()
+  projectId: string;
+
+  @Property()
+  percentage: number;
+
+  @Property()
+  amountDue: number;
+
+  @Property()
+  @Default(false)
+  paid: boolean;
+
+  @Property()
+  paidAt?: Date;
+
+  @Property()
+  @Default(() => new Date())
+  createdAt: Date;
+
+  @Property()
+  @Default(() => new Date())
+  updatedAt: Date;
+
+  @Ref(() => AdminModel)
+  technician: Ref<AdminModel>;
+
+  @Ref(() => ProjectModel)
+  project: Ref<ProjectModel>;
+}

--- a/server/src/services/AccountsPayableService.ts
+++ b/server/src/services/AccountsPayableService.ts
@@ -1,0 +1,57 @@
+import { Inject, Injectable } from "@tsed/di";
+import { MongooseModel } from "@tsed/mongoose";
+import { BadRequest } from "@tsed/exceptions";
+import { AccountsPayableModel } from "../models/AccountsPayableModel";
+import { ProjectModel } from "../models/ProjectModel";
+
+interface AllocationInput {
+  technicianId: string;
+  percentage: number;
+}
+
+@Injectable()
+export class AccountsPayableService {
+  constructor(
+    @Inject(AccountsPayableModel)
+    private payableModel: MongooseModel<AccountsPayableModel>,
+    @Inject(ProjectModel)
+    private projectModel: MongooseModel<ProjectModel>
+  ) {}
+
+  public async upsertAllocations(projectId: string, allocations: AllocationInput[]) {
+    const total = allocations.reduce((sum, a) => sum + a.percentage, 0);
+    if (total > 100) {
+      throw new BadRequest("Total allocation percentage cannot exceed 100");
+    }
+
+    const project = await this.projectModel.findById(projectId).lean();
+    const contract = project?.contractAmount || 0;
+
+    const results: AccountsPayableModel[] = [];
+    for (const alloc of allocations) {
+      const amountDue = (contract * alloc.percentage) / 100;
+      const record = await this.payableModel.findOneAndUpdate(
+        { projectId, technicianId: alloc.technicianId },
+        { projectId, technicianId: alloc.technicianId, percentage: alloc.percentage, amountDue },
+        { upsert: true, new: true }
+      );
+      results.push(record);
+    }
+    return results;
+  }
+
+  public async listByPaidStatus(paid: boolean) {
+    return this.payableModel
+      .find({ paid })
+      .populate("technicianId", "name")
+      .populate("projectId", "homeowner");
+  }
+
+  public async markPaid(id: string) {
+    return this.payableModel.findByIdAndUpdate(
+      id,
+      { paid: true, paidAt: new Date() },
+      { new: true }
+    );
+  }
+}

--- a/tests/server/controllers/AccountsPayableController.test.ts
+++ b/tests/server/controllers/AccountsPayableController.test.ts
@@ -1,0 +1,51 @@
+import { PlatformTest } from "@tsed/common";
+import SuperTest from "supertest";
+import { Server } from "../../server/src/Server";
+import { AccountsPayableService } from "../../server/src/services/AccountsPayableService";
+
+describe("AccountsPayableController", () => {
+  let request: SuperTest.SuperTest<SuperTest.Test>;
+  let service: AccountsPayableService;
+
+  beforeEach(PlatformTest.bootstrap(Server));
+  beforeEach(() => {
+    request = SuperTest(PlatformTest.callback());
+    service = PlatformTest.injector.get(AccountsPayableService)!;
+  });
+
+  afterEach(PlatformTest.reset);
+
+  it("GET /accounts-payable", async () => {
+    const items = [{ _id: "1" }] as any;
+    jest.spyOn(service, "listByPaidStatus").mockResolvedValue(items);
+
+    const res = await request.get("/rest/accounts-payable").query({ paid: "false" }).expect(200);
+
+    expect(service.listByPaidStatus).toHaveBeenCalledWith(false);
+    expect(res.body).toEqual({ success: true, data: items });
+  });
+
+  it("POST /projects/:id/accounts-payable", async () => {
+    const items = [{ _id: "1" }] as any;
+    const payload = { allocations: [{ technicianId: "t", percentage: 50 }] };
+    jest.spyOn(service, "upsertAllocations").mockResolvedValue(items);
+
+    const res = await request
+      .post("/rest/projects/p1/accounts-payable")
+      .send(payload)
+      .expect(200);
+
+    expect(service.upsertAllocations).toHaveBeenCalledWith("p1", payload.allocations);
+    expect(res.body).toEqual({ success: true, data: items });
+  });
+
+  it("PATCH /accounts-payable/:id/pay", async () => {
+    const item = { _id: "1" } as any;
+    jest.spyOn(service, "markPaid").mockResolvedValue(item);
+
+    const res = await request.patch("/rest/accounts-payable/1/pay").expect(200);
+
+    expect(service.markPaid).toHaveBeenCalledWith("1");
+    expect(res.body).toEqual({ success: true, data: item });
+  });
+});

--- a/tests/server/services/AccountsPayableService.test.ts
+++ b/tests/server/services/AccountsPayableService.test.ts
@@ -1,0 +1,50 @@
+import { AccountsPayableService } from '../../../server/src/services/AccountsPayableService';
+
+describe('AccountsPayableService', () => {
+  let payableModel: any;
+  let projectModel: any;
+  let service: AccountsPayableService;
+
+  beforeEach(() => {
+    payableModel = {
+      findOneAndUpdate: jest.fn(),
+      find: jest.fn(),
+      findByIdAndUpdate: jest.fn()
+    } as any;
+    projectModel = {
+      findById: jest.fn()
+    } as any;
+    service = new AccountsPayableService(payableModel, projectModel);
+  });
+
+  it('validates allocation percentages', async () => {
+    await expect(
+      service.upsertAllocations('p1', [
+        { technicianId: 't1', percentage: 60 },
+        { technicianId: 't2', percentage: 50 }
+      ])
+    ).rejects.toThrow('Total allocation percentage cannot exceed 100');
+  });
+
+  it('upserts allocations with computed amount', async () => {
+    projectModel.findById.mockResolvedValue({ contractAmount: 1000 });
+    payableModel.findOneAndUpdate.mockResolvedValue({});
+
+    await service.upsertAllocations('p1', [
+      { technicianId: 't1', percentage: 50 }
+    ]);
+
+    expect(projectModel.findById).toHaveBeenCalledWith('p1');
+    expect(payableModel.findOneAndUpdate).toHaveBeenCalledWith(
+      { projectId: 'p1', technicianId: 't1' },
+      { projectId: 'p1', technicianId: 't1', percentage: 50, amountDue: 500 },
+      { upsert: true, new: true }
+    );
+  });
+
+  it('marks payable as paid', async () => {
+    payableModel.findByIdAndUpdate.mockResolvedValue({});
+    await service.markPaid('1');
+    expect(payableModel.findByIdAndUpdate).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add AccountsPayableModel
- create AccountsPayableService with allocation helpers
- expose REST APIs via AccountsPayableController
- export controller
- test new service and controller

## Testing
- `npm test` *(fails: ESLint couldn't find plugin)*