### PR TITLE
[VOLTA] Implement project detail payroll page

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from "react";
+import {
+  Box,
+  Heading,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Stack,
+  Select,
+  Input,
+  Text,
+  Button,
+} from "@chakra-ui/react";
+import { useParams } from "react-router-dom";
+import { baseURL } from "../apiConfig";
+import { Project } from "../store/projectsSlice";
+import { User } from "../store/usersSlice";
+import { useAppDispatch } from "../store";
+import { savePayroll } from "../store/projectsSlice";
+
+const ProjectDetailPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const dispatch = useAppDispatch();
+  const [project, setProject] = useState<Project | null>(null);
+  const [techUsers, setTechUsers] = useState<User[]>([]);
+  const [assignedTechIds, setAssignedTechIds] = useState<string[]>(["", "", "", ""]);
+  const [percents, setPercents] = useState<number[]>([0, 0, 0, 0]);
+
+  useEffect(() => {
+    if (!id) return;
+    fetch(`${baseURL}/projects/${id}`)
+      .then((res) => res.json())
+      .then((d) => setProject(d.data))
+      .catch(() => setProject(null));
+    fetch(`${baseURL}/users`)
+      .then((res) => res.json())
+      .then((d) => setTechUsers(d.data.filter((u: User) => u.role === "tech")))
+      .catch(() => setTechUsers([]));
+  }, [id]);
+
+  const handleTechChange = (idx: number, val: string) => {
+    setAssignedTechIds((prev) => {
+      const arr = [...prev];
+      arr[idx] = val;
+      return arr;
+    });
+  };
+
+  const handlePercentChange = (idx: number, val: string) => {
+    setPercents((prev) => {
+      const arr = [...prev];
+      arr[idx] = Number(val);
+      return arr;
+    });
+  };
+
+  const allocations = assignedTechIds
+    .map((techId, i) => ({ technicianId: techId, percent: percents[i] }))
+    .filter((a) => a.technicianId);
+
+  const totals = allocations.map((a) =>
+    ((project?.contractAmount || 0) * a.percent) / 100
+  );
+
+  const handleSave = () => {
+    if (!id) return;
+    dispatch(
+      savePayroll({ projectId: id, allocations })
+    );
+  };
+
+  return (
+    <Box>
+      <Heading size="lg" mb={4}>
+        Project Details
+      </Heading>
+      <Tabs>
+        <TabList>
+          <Tab>Project</Tab>
+          <Tab>Payroll</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <pre className="text-sm bg-gray-100 p-2 rounded">
+              {JSON.stringify(project, null, 2)}
+            </pre>
+          </TabPanel>
+          <TabPanel>
+            <Stack spacing={3} maxW="sm">
+              {assignedTechIds.map((val, i) => (
+                <Stack key={i} direction="row" align="center">
+                  <Select
+                    placeholder="Select Technician"
+                    value={val}
+                    onChange={(e) => handleTechChange(i, e.target.value)}
+                  >
+                    {techUsers.map((t) => (
+                      <option key={t._id} value={t._id || ""}>
+                        {t.name}
+                      </option>
+                    ))}
+                  </Select>
+                  <Input
+                    type="number"
+                    placeholder="%"
+                    value={percents[i]}
+                    onChange={(e) => handlePercentChange(i, e.target.value)}
+                  />
+                </Stack>
+              ))}
+              <Box>
+                {allocations.map((a, idx) => {
+                  const tech = techUsers.find((t) => t._id === a.technicianId);
+                  return (
+                    <Text key={a.technicianId}>
+                      {tech?.name || "-"}: ${totals[idx].toFixed(2)}
+                    </Text>
+                  );
+                })}
+                <Text fontWeight="bold" mt={2}>
+                  Total: $
+                  {totals.reduce((s, v) => s + v, 0).toFixed(2)}
+                </Text>
+              </Box>
+              <Button onClick={handleSave} colorScheme="blue">
+                Save Payroll
+              </Button>
+            </Stack>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+};
+
+export default ProjectDetailPage;

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -5,6 +5,7 @@ import Login from './pages/Login';
 import Register from './pages/Register';
 import UserManagementPage from './pages/UserManagementPage';
 import ProjectsPage from './pages/ProjectsPage';
+import ProjectDetailPage from './pages/ProjectDetailPage';
 import AccountsPayablePage from './pages/AccountsPayablePage';
 import TechnicianTasksPage from './pages/TechnicianTasksPage';
 import Layout from './components/Layout';
@@ -25,6 +26,7 @@ const AppRoutes: React.FC = () => (
     >
       <Route index element={<Navigate to="projects" replace />} />
       <Route path="projects" element={<ProjectsPage />} />
+      <Route path="projects/:id" element={<ProjectDetailPage />} />
       <Route path="accounts" element={<AccountsPayablePage />} />
       <Route path="users" element={<UserManagementPage />} />
       <Route path="technician" element={<TechnicianTasksPage />} />

--- a/client/src/store/projectsSlice.ts
+++ b/client/src/store/projectsSlice.ts
@@ -58,6 +58,19 @@ export const createProject = createAsyncThunk(
   }
 );
 
+export const savePayroll = createAsyncThunk(
+  "projects/savePayroll",
+  async ({ projectId, allocations }: { projectId: string; allocations: { technicianId: string; percent: number }[] }) => {
+    const res = await fetch(`/api/projects/${projectId}/accounts-payable`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ allocations }),
+    });
+    if (!res.ok) throw new Error("Failed to save payroll");
+    return true;
+  }
+);
+
 const projectsSlice = createSlice({
   name: "projects",
   initialState,

--- a/tests/client/pages/project-detail/ProjectDetailPage.test.tsx
+++ b/tests/client/pages/project-detail/ProjectDetailPage.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import ProjectDetailPage from "../../../../client/src/pages/ProjectDetailPage";
+import { Provider } from "../../../../client/src/components/ui/provider";
+import "@testing-library/jest-dom";
+
+describe("ProjectDetailPage", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { _id: "1", homeowner: "H", contractAmount: 100 } })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ _id: "t1", name: "Tech", role: "tech" }] })
+      });
+  });
+
+  afterEach(() => {
+    (global.fetch as jest.Mock).mockRestore();
+  });
+
+  it("renders payroll tab", async () => {
+    render(
+      <Provider>
+        <MemoryRouter initialEntries={["/dashboard/projects/1"]}>
+          <Routes>
+            <Route path="/dashboard/projects/:id" element={<ProjectDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(await screen.findByText(/Project Details/i)).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Payroll/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- create `ProjectDetailPage` with technician allocation and payroll tab
- wire new page into dashboard routes
- add `savePayroll` thunk for posting payroll allocations
- test project detail page rendering

## Testing
- `npm test` *(fails: ESLint couldn't find plugin `@typescript-eslint/eslint-plugin`)*