### PR TITLE
[VOLTA] implement accounts payable UI slice

### DIFF
--- a/client/src/pages/AccountsPayablePage.tsx
+++ b/client/src/pages/AccountsPayablePage.tsx
@@ -1,8 +1,71 @@
-import React from 'react'
-import { Heading } from '@chakra-ui/react'
+import React, { useEffect } from "react";
+import {
+  Box,
+  Heading,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Checkbox,
+  useToast,
+} from "@chakra-ui/react";
+import { fetchUnpaid, markPaid } from "../store/accountsPayableSlice";
+import { useAppDispatch, useAppSelector } from "../store";
 
-const AccountsPayablePage: React.FC = () => (
-  <Heading size="md">Accounts Payable</Heading>
-)
+const AccountsPayablePage: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const records = useAppSelector((s) => s.accountsPayable.items);
+  const toast = useToast();
 
-export default AccountsPayablePage
+  useEffect(() => {
+    dispatch(fetchUnpaid());
+  }, [dispatch]);
+
+  const handlePaid = async (id: string) => {
+    try {
+      await dispatch(markPaid(id)).unwrap();
+      toast({ title: "Marked as paid", status: "success", duration: 2000, isClosable: true });
+    } catch {
+      toast({ title: "Failed to mark paid", status: "error", duration: 2000, isClosable: true });
+    }
+  };
+
+  return (
+    <Box p={4} overflowX="auto">
+      <Heading size="md" mb={4}>
+        Accounts Payable
+      </Heading>
+      <Table size="sm">
+        <Thead>
+          <Tr>
+            <Th>Project</Th>
+            <Th>Technician</Th>
+            <Th textAlign="center">Paid</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {records.map((r) => (
+            <Tr key={r._id}>
+              <Td>{r.project}</Td>
+              <Td>{r.technician}</Td>
+              <Td textAlign="center">
+                <Checkbox onChange={() => handlePaid(r._id)} />
+              </Td>
+            </Tr>
+          ))}
+          {records.length === 0 && (
+            <Tr>
+              <Td colSpan={3} className="text-center">
+                No data
+              </Td>
+            </Tr>
+          )}
+        </Tbody>
+      </Table>
+    </Box>
+  );
+};
+
+export default AccountsPayablePage;

--- a/client/src/store/accountsPayableSlice.ts
+++ b/client/src/store/accountsPayableSlice.ts
@@ -1,0 +1,58 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { baseURL } from "../apiConfig";
+
+export interface PayableRecord {
+  _id: string;
+  project: string;
+  technician: string;
+}
+
+interface AccountsPayableState {
+  items: PayableRecord[];
+  status: "idle" | "loading" | "failed";
+}
+
+const initialState: AccountsPayableState = {
+  items: [],
+  status: "idle",
+};
+
+export const fetchUnpaid = createAsyncThunk("accountsPayable/fetchUnpaid", async () => {
+  const res = await fetch(`${baseURL}/accounts-payable/unpaid`);
+  if (!res.ok) throw new Error("Failed to load payable records");
+  const data = await res.json();
+  return data.data as PayableRecord[];
+});
+
+export const markPaid = createAsyncThunk("accountsPayable/markPaid", async (id: string) => {
+  const res = await fetch(`${baseURL}/accounts-payable/${id}/paid`, {
+    method: "POST",
+  });
+  if (!res.ok) throw new Error("Failed to mark record paid");
+  const data = await res.json();
+  return data.data as PayableRecord;
+});
+
+const accountsPayableSlice = createSlice({
+  name: "accountsPayable",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchUnpaid.pending, (state) => {
+        state.status = "loading";
+      })
+      .addCase(fetchUnpaid.fulfilled, (state, action) => {
+        state.status = "idle";
+        state.items = action.payload;
+      })
+      .addCase(fetchUnpaid.rejected, (state) => {
+        state.status = "failed";
+      })
+      .addCase(markPaid.pending, (state, action) => {
+        state.items = state.items.filter((r) => r._id !== action.meta.arg);
+      });
+  },
+});
+
+export default accountsPayableSlice.reducer;

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -3,6 +3,7 @@ import authReducer from './authSlice'
 import dealsReducer from './dealsSlice'
 import projectsReducer from './projectsSlice'
 import usersReducer from './usersSlice'
+import accountsPayableReducer from './accountsPayableSlice'
 import { useDispatch, TypedUseSelectorHook, useSelector } from 'react-redux'
 
 export const store = configureStore({
@@ -10,7 +11,8 @@ export const store = configureStore({
     auth: authReducer,
     deals: dealsReducer,
     projects: projectsReducer,
-    users: usersReducer
+    users: usersReducer,
+    accountsPayable: accountsPayableReducer
   }
 })
 

--- a/tests/client/pages/accounts-payable/AccountsPayable.test.tsx
+++ b/tests/client/pages/accounts-payable/AccountsPayable.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import AccountsPayable from "../../../../client/src/pages/AccountsPayable";
+import AccountsPayablePage from "../../../../client/src/pages/AccountsPayablePage";
+import { Provider } from "../../../../client/src/components/ui/provider";
 
 describe("AccountsPayable page", () => {
   it("renders heading and placeholder row", () => {
-    render(<AccountsPayable />);
+    render(
+      <Provider>
+        <AccountsPayablePage />
+      </Provider>
+    );
     expect(
       screen.getByRole("heading", { name: /accounts payable/i })
     ).toBeInTheDocument();

--- a/tests/client/redux/accountsPayableSlice.test.ts
+++ b/tests/client/redux/accountsPayableSlice.test.ts
@@ -1,0 +1,18 @@
+import reducer, { fetchUnpaid, markPaid, PayableRecord } from '../../../client/src/store/accountsPayableSlice'
+
+describe('accountsPayableSlice', () => {
+  it('stores records on fetch', () => {
+    const pending = reducer(undefined, fetchUnpaid.pending(''))
+    expect(pending.status).toBe('loading')
+    const items: PayableRecord[] = [{ _id: '1', project: 'P', technician: 'T' }]
+    const next = reducer(pending, fetchUnpaid.fulfilled(items, ''))
+    expect(next.items).toEqual(items)
+    expect(next.status).toBe('idle')
+  })
+
+  it('optimistically removes item when marking paid', () => {
+    const start = { items: [{ _id: '1', project: 'P', technician: 'T' }], status: 'idle' as const }
+    const next = reducer(start, markPaid.pending('req', '1'))
+    expect(next.items).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- add AccountsPayable slice with thunks
- register new slice in store
- build AccountsPayablePage with table and optimistic checkbox
- test AccountsPayable slice and page

## Testing
- `npm test` *(fails: eslint plugin missing)*
- `npx jest --selectProjects=client` *(fails: EHOSTUNREACH)*