### PR TITLE
[VOLTA] add accounts payable model

### DIFF
--- a/server/src/models/AccountPayableModel.ts
+++ b/server/src/models/AccountPayableModel.ts
@@ -1,0 +1,58 @@
+import { Property } from "@tsed/schema";
+import {
+  Model,
+  ObjectID,
+  Ref,
+  Indexed,
+  MongooseIndex,
+  PreHook
+} from "@tsed/mongoose";
+import mongoose from "mongoose";
+import { ProjectModel } from "./ProjectModel";
+import { AdminModel } from "./AdminModel";
+
+@Model({ name: "accountPayable" })
+@MongooseIndex({ projectId: 1, technicianId: 1 })
+@MongooseIndex({ paid: 1 })
+export class AccountPayableModel {
+  @ObjectID("id")
+  _id: string;
+
+  @Ref(() => ProjectModel)
+  @Property()
+  projectId: Ref<ProjectModel>;
+
+  @Ref(() => AdminModel)
+  @Property()
+  technicianId: Ref<AdminModel>;
+
+  @Property()
+  allocationPercent: number;
+
+  @Property()
+  amountDue: number;
+
+  @Property()
+  @Indexed()
+  paid: boolean;
+
+  @Property()
+  paidAt?: Date;
+
+  @PreHook("save")
+  static async preSave(doc: AccountPayableModel, next: () => void) {
+    if (doc.projectId && doc.allocationPercent != null) {
+      try {
+        const Project = mongoose.model<ProjectModel & mongoose.Document>("project");
+        const project = await Project.findById(doc.projectId).lean();
+        if (project && typeof project.contractAmount === "number") {
+          doc.amountDue =
+            (project.contractAmount * doc.allocationPercent) / 100;
+        }
+      } catch {
+        // ignore lookup errors
+      }
+    }
+    next();
+  }
+}

--- a/tests/server/models/AccountPayableModel.test.ts
+++ b/tests/server/models/AccountPayableModel.test.ts
@@ -1,0 +1,15 @@
+import mongoose from "mongoose";
+import { AccountPayableModel } from "../../../server/src/models/AccountPayableModel";
+
+describe("AccountPayableModel preSave", () => {
+  it("computes amountDue from project", async () => {
+    const findById = jest.fn().mockResolvedValue({ contractAmount: 1000 });
+    jest.spyOn(mongoose, "model").mockReturnValue({ findById } as any);
+
+    const doc: any = { projectId: "p1", allocationPercent: 25 };
+    await AccountPayableModel.preSave(doc, () => {});
+
+    expect(findById).toHaveBeenCalledWith("p1");
+    expect(doc.amountDue).toBe(250);
+  });
+});


### PR DESCRIPTION
## Summary
- implement AccountPayableModel with indexes and pre-save hook
- verify amountDue calculation in new unit test

## Testing
- `npm test` *(fails: eslint plugin missing)*