### PR TITLE
[VOLTA] add edit link to projects table

### DIFF
--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { EditIcon } from "@chakra-ui/icons";
 import { fetchProjects, createProject, Project } from "../store/projectsSlice";
 import { useAppDispatch, useAppSelector } from "../store";
 import AddProjectModal from "../components/AddProjectModal";
@@ -74,6 +76,15 @@ const ProjectsPage: React.FC = () => {
   };
 
   const columns: DataTableColumn<Project>[] = [
+    {
+      header: "",
+      key: "edit",
+      renderCell: (p: Project) => (
+        <Link to={`/dashboard/projects/${p._id}`} aria-label="Edit Project">
+          <EditIcon />
+        </Link>
+      ),
+    },
     { header: "Homeowner", key: "homeowner" },
     { header: "Sale Date", key: "saleDate" },
     { header: "Products", key: "products" },

--- a/tests/client/pages/projects/EditNavigation.test.tsx
+++ b/tests/client/pages/projects/EditNavigation.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import ProjectsPage from "../../../../client/src/pages/ProjectsPage";
+import ProjectDetailPage from "../../../../client/src/pages/ProjectDetailPage";
+import { Provider } from "../../../../client/src/components/ui/provider";
+import "@testing-library/jest-dom";
+
+beforeEach(() => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ data: [{ _id: "1", homeowner: "Jane" }] }),
+  })
+  .mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ data: { _id: "1", homeowner: "Jane" } }),
+  })
+  .mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ data: [] }),
+  });
+});
+
+afterEach(() => {
+  (global.fetch as jest.Mock).mockRestore();
+});
+
+test("navigates to project detail page", async () => {
+  render(
+    <Provider>
+      <MemoryRouter initialEntries={["/dashboard/projects"]}>
+        <Routes>
+          <Route path="/dashboard/projects" element={<ProjectsPage />} />
+          <Route path="/dashboard/projects/:id" element={<ProjectDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(await screen.findByText("Jane")).toBeInTheDocument();
+  fireEvent.click(screen.getByLabelText(/edit project/i));
+  expect(await screen.findByText(/project details/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- show an edit icon next to each project row
- navigate to the project details page when the icon is clicked
- test project detail navigation

## Testing
- `npm run lint --workspace client` *(fails: Missing script: "lint")*
- `npm run test:lint --workspace server` *(fails: ESLint couldn't find plugin)*
- `npm test` *(fails during server lint step)*