### PR TITLE
[VOLTA] Fix project detail navigation

### DIFF
--- a/client/src/pages/ProjectsPage.tsx
+++ b/client/src/pages/ProjectsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { EditIcon } from "@chakra-ui/icons";
 import { fetchProjects, createProject, Project } from "../store/projectsSlice";
 import { useAppDispatch, useAppSelector } from "../store";
@@ -10,6 +10,7 @@ import DataTable, { DataTableColumn } from "../components/DataTable";
 
 const ProjectsPage: React.FC = () => {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const projects = useAppSelector((state) => state.projects.items);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
@@ -75,14 +76,22 @@ const ProjectsPage: React.FC = () => {
     window.alert(`${rows.length} Projects Uploaded`);
   };
 
+  const navigateToProject = (id: string) => {
+    navigate(`/dashboard/projects/${id}`);
+  };
+
   const columns: DataTableColumn<Project>[] = [
     {
       header: "",
       key: "edit",
       renderCell: (p: Project) => (
-        <Link to={`/dashboard/projects/${p._id}`} aria-label="Edit Project">
+        <button
+          onClick={() => navigateToProject(p._id!)}
+          className="p-1 hover:bg-gray-100 rounded"
+          aria-label="Edit Project"
+        >
           <EditIcon />
-        </Link>
+        </button>
       ),
     },
     { header: "Homeowner", key: "homeowner" },


### PR DESCRIPTION
## Summary
- wire project edit button to use `useNavigate`
- navigate to `/dashboard/projects/<id>` when clicking edit icon

## Testing
- `npm test` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*