### PR TITLE
[VOLTA] fix project detail fetch

### DIFF
--- a/server/src/controllers/rest/ProjectController.ts
+++ b/server/src/controllers/rest/ProjectController.ts
@@ -1,6 +1,7 @@
 import { Controller, Inject } from "@tsed/di";
 import { BodyParams, MultipartFile, PlatformMulterFile, QueryParams, PathParams } from "@tsed/common";
 import { Get, Post, Patch, Returns } from "@tsed/schema";
+import { NotFound } from "@tsed/exceptions";
 import { ProjectModel } from "../../models/ProjectModel";
 import { ProjectService, parseCSV, transformCSVToProject } from "../../services/ProjectService";
 import { SuccessArrayResult, SuccessResult } from "../../util/entities";
@@ -28,6 +29,9 @@ export class ProjectController {
   @(Returns(200, SuccessResult).Of(ProjectModel))
   public async getById(@PathParams("id") id: string) {
     const project = await this.projectService.findById(id);
+    if (!project) {
+      throw new NotFound(`Project with id ${id} not found`);
+    }
     return new SuccessResult(project, ProjectModel);
   }
 

--- a/server/src/services/ProjectService.ts
+++ b/server/src/services/ProjectService.ts
@@ -63,7 +63,7 @@ export class ProjectService {
   }
 
   public async findById(id: string) {
-    return this.projectModel.findById(id);
+    return this.projectModel.findById(id).exec();
   }
 
   public async updateProject(id: string, data: Partial<ProjectModel>) {

--- a/tests/server/controllers/ProjectController.test.ts
+++ b/tests/server/controllers/ProjectController.test.ts
@@ -45,6 +45,15 @@ describe("ProjectController", () => {
     expect(res.body).toEqual({ success: true, data: proj });
   });
 
+  it("GET /projects/:id returns 404 when missing", async () => {
+    jest.spyOn(projectService, "findById").mockResolvedValue(null as any);
+
+    const res = await request.get("/rest/projects/1").expect(404);
+
+    expect(projectService.findById).toHaveBeenCalledWith("1");
+    expect(res.body.message).toMatch(/not found/i);
+  });
+
   it("PATCH /projects/:id updates project", async () => {
     const proj = { _id: "1", homeowner: "Jane" } as any;
     jest.spyOn(projectService, "updateProject").mockResolvedValue(proj);


### PR DESCRIPTION
## Summary
- return 404 when project id is not found
- execute DB lookup using `.exec()`
- cover 404 case in project controller tests

## Testing
- `npm test` *(fails: ESLint plugin missing)*