### PR TITLE
[VOLTA] Technician payroll accounts payable flow

### DIFF
--- a/client/src/pages/AccountsPayablePage.tsx
+++ b/client/src/pages/AccountsPayablePage.tsx
@@ -23,9 +23,14 @@ const AccountsPayablePage: React.FC = () => {
     dispatch(fetchUnpaid());
   }, [dispatch]);
 
-  const handlePaid = async (id: string) => {
+  const handlePaid = async (projectId: string, techId: string) => {
+    const payroll = records.filter(r => r.projectId === projectId).map(r => ({
+      technicianId: r.techId,
+      percentage: r.allocationPct,
+      paid: r.projectId === projectId && r.techId === techId ? true : r.paid,
+    }));
     try {
-      await dispatch(markPaid(id)).unwrap();
+      await dispatch(markPaid({ projectId, payroll })).unwrap();
       toast({ title: "Marked as paid", status: "success", duration: 2000, isClosable: true });
     } catch {
       toast({ title: "Failed to mark paid", status: "error", duration: 2000, isClosable: true });
@@ -33,25 +38,29 @@ const AccountsPayablePage: React.FC = () => {
   };
 
   return (
-    <Box p={4} overflowX="auto">
+    <Box p={4} className="overflow-x-auto bg-gray-50">
       <Heading size="md" mb={4}>
         Accounts Payable
       </Heading>
-      <Table size="sm">
-        <Thead>
+      <Table size="sm" className="min-w-max">
+        <Thead className="sticky top-0 bg-white">
           <Tr>
             <Th>Project</Th>
             <Th>Technician</Th>
+            <Th>Allocation %</Th>
+            <Th>Payout</Th>
             <Th textAlign="center">Paid</Th>
           </Tr>
         </Thead>
         <Tbody>
-          {records.map((r) => (
-            <Tr key={r._id}>
-              <Td>{r.project}</Td>
-              <Td>{r.technician}</Td>
+          {records.map((r, i) => (
+            <Tr key={i}>
+              <Td>{r.projectName}</Td>
+              <Td>{r.techId}</Td>
+              <Td>{r.allocationPct}</Td>
+              <Td>${r.amountDue.toFixed(2)}</Td>
               <Td textAlign="center">
-                <Checkbox onChange={() => handlePaid(r._id)} />
+                <Checkbox isChecked={r.paid} onChange={() => handlePaid(r.projectId, r.techId)} />
               </Td>
             </Tr>
           ))}

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -51,6 +51,15 @@ const ProjectDetailPage: React.FC = () => {
     }
   }, [projectId, dispatch, users.length]);
 
+  useEffect(() => {
+    if (project && project.payroll) {
+      const ids = project.payroll.map((p: any) => p.technicianId);
+      const percs = project.payroll.map((p: any) => p.percentage);
+      setAssignedTechIds((prev) => ids.concat(Array(4 - ids.length).fill("")));
+      setPercents((prev) => percs.concat(Array(4 - percs.length).fill(0)));
+    }
+  }, [project]);
+
   const handleTechChange = (idx: number, val: string) => {
     setAssignedTechIds((prev) => {
       const arr = [...prev];
@@ -81,7 +90,8 @@ const ProjectDetailPage: React.FC = () => {
 
   const handleSave = () => {
     if (!projectId) return;
-    dispatch(updateProjectPayroll({ id: projectId, technicians: allocations }));
+    const payroll = allocations.map((a) => ({ technicianId: a.userId, percentage: a.allocationPercent }));
+    dispatch(updateProjectPayroll({ id: projectId, payroll }));
   };
 
   return (

--- a/client/src/store/projectsSlice.ts
+++ b/client/src/store/projectsSlice.ts
@@ -79,19 +79,18 @@ export const fetchProjectById = createAsyncThunk(
 export const updateProjectPayroll = createAsyncThunk(
   "projects/updatePayroll",
   async (
-    { id, technicians }: { id: string; technicians: any[] },
+    { id, payroll }: { id: string; payroll: { technicianId: string; percentage: number; paid?: boolean }[] },
     { dispatch }
   ) => {
-    const res = await fetch(`${baseURL}/projects/${id}`, {
+    const res = await fetch(`${baseURL}/projects/${id}/payroll`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ technicians }),
+      body: JSON.stringify({ payroll }),
     });
     if (!res.ok) throw new Error("Failed to update project payroll");
     await dispatch(fetchProjectById(id));
     const data = await res.json();
-    const p = data.data as any;
-    return { ...p, _id: p._id || p.id } as Project;
+    return data.data;
   }
 );
 

--- a/server/src/services/AccountsPayableService.ts
+++ b/server/src/services/AccountsPayableService.ts
@@ -54,4 +54,29 @@ export class AccountsPayableService {
       { new: true }
     );
   }
+
+  public async listAllByProject() {
+    const projects = await this.payableModel
+      .find()
+      .populate('technicianId', 'name')
+      .populate('projectId', 'homeowner');
+    const map = new Map<string, any>();
+    for (const rec of projects) {
+      const pid = (rec.projectId as any)._id.toString();
+      if (!map.has(pid)) {
+        map.set(pid, {
+          projectId: pid,
+          projectName: (rec.projectId as any).homeowner,
+          payroll: [] as any[],
+        });
+      }
+      map.get(pid).payroll.push({
+        techId: (rec.technicianId as any)._id.toString(),
+        allocationPct: rec.percentage,
+        paid: rec.paid,
+        amountDue: rec.amountDue,
+      });
+    }
+    return Array.from(map.values());
+  }
 }

--- a/tests/client/pages/accounts-payable/AccountsPayable.test.tsx
+++ b/tests/client/pages/accounts-payable/AccountsPayable.test.tsx
@@ -1,9 +1,0 @@
-import { render, screen } from "@testing-library/react";
-import "@testing-library/jest-dom";
-import AccountsPayablePage from "../../../../client/src/pages/AccountsPayablePage";
-
-    expect(
-      screen.getByRole("heading", { name: /accounts payable/i })
-    ).toBeInTheDocument();
-  });
-});

--- a/tests/client/pages/accounts-payable/AccountsPayablePage.test.tsx
+++ b/tests/client/pages/accounts-payable/AccountsPayablePage.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { Provider } from '../../../../client/src/components/ui/provider';
+import AccountsPayablePage from '../../../../client/src/pages/AccountsPayablePage';
+import '@testing-library/jest-dom';
+
+global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ data: [] }) })) as any;
+
+describe('AccountsPayablePage', () => {
+  it('renders table', async () => {
+    render(
+      <Provider>
+        <AccountsPayablePage />
+      </Provider>
+    );
+    expect(screen.getByRole('heading', { name: /accounts payable/i })).toBeInTheDocument();
+  });
+});

--- a/tests/client/pages/project-detail/ProjectDetailPage.test.tsx
+++ b/tests/client/pages/project-detail/ProjectDetailPage.test.tsx
@@ -9,7 +9,7 @@ describe("ProjectDetailPage", () => {
     global.fetch = jest.fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({ data: { id: "1", homeowner: "H", contractAmount: 100 } })
+        json: () => Promise.resolve({ data: { id: "1", homeowner: "H", contractAmount: 100, payroll: [{ technicianId: 't1', percentage: 50 }] } })
       })
       .mockResolvedValueOnce({
         ok: true,

--- a/tests/server/services/ProjectPayroll.test.ts
+++ b/tests/server/services/ProjectPayroll.test.ts
@@ -1,0 +1,34 @@
+import { ProjectService } from '../../../server/src/services/ProjectService';
+
+describe('ProjectService payroll helpers', () => {
+  let service: ProjectService;
+  let projectModel: any;
+  let payableModel: any;
+  let payableService: any;
+
+  beforeEach(() => {
+    projectModel = {
+      findById: jest.fn()
+    } as any;
+    payableModel = {
+      find: jest.fn(),
+      findOneAndUpdate: jest.fn()
+    } as any;
+    payableService = { listAllByProject: jest.fn() } as any;
+    service = new ProjectService(projectModel, payableModel, payableService);
+  });
+
+  it('gets payroll records', async () => {
+    payableModel.find.mockReturnValue({ lean: () => ({ exec: () => Promise.resolve([{ technicianId: 't1' }]) }) });
+    const res = await service.getPayroll('p1');
+    expect(res[0].technicianId).toBe('t1');
+  });
+
+  it('updates payroll entries', async () => {
+    projectModel.findById.mockResolvedValue({ contractAmount: 100 });
+    payableModel.findOneAndUpdate.mockResolvedValue({});
+
+    await service.updatePayroll('p1', [{ technicianId: 't', percentage: 50 }]);
+    expect(payableModel.findOneAndUpdate).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- extend ProjectService with payroll helpers
- add payroll endpoints to ProjectController
- list all accounts via AccountsPayableService
- wire payroll editing in ProjectDetailPage
- show global AccountsPayablePage with payout table
- update redux slices for new API calls
- add minimal tests for payroll services and pages

## Testing
- `npm test` *(fails: ESLint couldn't find plugin)*