### PR TITLE
[VOLTA] unify root jest+eslint configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,26 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: [
+      './server/tsconfig.json',
+      './client/tsconfig.json'
+    ]
+  },
+  ignorePatterns: [
+    'node_modules/',
+    'client/jest.config.js',
+    'server/jest.config.js',
+    'server/webpack.config.js',
+    'tests/**/*.js'
+  ],
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended'
+  ],
+  rules: {
+    // Add any project-specific overrides here
+  }
+};

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,9 +1,11 @@
 module.exports = {
+  displayName: 'client-tests',
   testEnvironment: 'jsdom',
-  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleFileExtensions: ['ts','tsx','js','jsx'],
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest'
   },
   setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  testMatch: ['<rootDir>/tests/client/**/*.{test,spec}.{ts,tsx}'],
   verbose: true
-}
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,11 @@
 module.exports = {
   projects: [
-    "<rootDir>/client/jest.config.js",
-    "<rootDir>/server/jest.config.js",
+    '<rootDir>/server/jest.config.js',
+    '<rootDir>/client/jest.config.js'
   ],
-  verbose: true,
+  testMatch: [
+    '<rootDir>/tests/server/**/*.test.ts',
+    '<rootDir>/tests/client/**/*.{test,spec}.{ts,tsx}'
+  ],
+  verbose: true
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "npm run dev",
     "dev:server": "npm --workspace server run dev",
     "dev:client": "npm --workspace client run dev",
-    "test": "npm run test:server && npm run test:client",
+    "test": "eslint . && npm run test:server && npm run test:client",
     "test:server": "npm --workspace server run test",
     "test:client": "npm --workspace client run test"
   },

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,5 +1,7 @@
-/* eslint-disable */
-
 module.exports = {
-  projects: ["<rootDir>/client/jest.config.js", "<rootDir>/server/jest.config.js"]
+  displayName: 'server-tests',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/tests/server/**/*.test.ts'],
+  moduleFileExtensions: ['ts','js','json'],
 };


### PR DESCRIPTION
## Summary
- add a monorepo `.eslintrc.js`
- configure root jest to find client and server tests
- update server and client jest configs
- run lint for both packages from root

## Testing
- `npm install` *(fails: plugin not found)*
- `npm test` *(fails: ESLint plugin missing)*