### PR TITLE
[VOLTA] map icon packages to local stubs

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -14,7 +14,11 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": "src"
+    "baseUrl": "src",
+    "paths": {
+      "react-icons/fi": ["icons"],
+      "@chakra-ui/icons": ["icons"]
+    }
   },
   "include": ["src", "src/**/*.tsx"]
 }


### PR DESCRIPTION
## Summary
- map `react-icons/fi` and `@chakra-ui/icons` to a local stub module via TS path aliases

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '../languages/js/source-code')*