### PR TITLE
[VOLTA] pin eslint version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "babel-jest": "^29.7.0",
         "concurrently": "^8.0.0",
         "cross-env": "^7.0.3",
-        "eslint": "^9.27.0",
+        "eslint": "8.57.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.3.4"


### PR DESCRIPTION
## Summary
- pin eslint 8.57.1 in package-lock

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/plugin-kit')*
- `npm test`