### PR TITLE
[VOLTA] update payroll save dispatch

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
     '^@chakra-ui/icons$': '<rootDir>/__mocks__/chakra.js',
     '^@chakra-ui/utils/.*$': '<rootDir>/__mocks__/chakra.js'
   },
-  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
-  testMatch: ['<rootDir>/tests/client/**/*.{test,spec}.{ts,tsx}'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
+  testMatch: ['<rootDir>/../tests/client/**/*.{test,spec}.{ts,tsx}'],
   verbose: true
 };

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -21,7 +21,7 @@ import { useParams } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../store";
 import {
   fetchProjectById,
-  updateProjectPayroll,
+  savePayroll,
   Project,
 } from "../store/projectsSlice";
 import { fetchUsers } from "../store/usersSlice";
@@ -131,16 +131,14 @@ const ProjectDetailPage: React.FC = () => {
 
   const handleSave = () => {
     if (!projectId) return;
-    const payroll = allocations.map((a) => ({
+    const allocationsPayload = allocations.map((a) => ({
       technicianId: a.userId,
-      percentage: a.allocationPercent,
+      percent: a.allocationPercent,
     }));
     dispatch(
-      updateProjectPayroll({
-        id: projectId,
-        payroll,
-        piecemealPercent:
-          typeof piecemealPercent === "number" ? piecemealPercent : 10,
+      savePayroll({
+        projectId,
+        allocations: allocationsPayload,
       })
     );
   };

--- a/tests/client/pages/project-detail/ProjectDetailPage.test.tsx
+++ b/tests/client/pages/project-detail/ProjectDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import ProjectDetailPage from "../../../../client/src/pages/ProjectDetailPage";
 import { Provider } from "../../../../client/src/components/ui/provider";
@@ -14,7 +14,8 @@ describe("ProjectDetailPage", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ data: [{ _id: "t1", name: "Tech", role: "tech" }] })
-      });
+      })
+      .mockResolvedValue({ ok: true });
   });
 
   afterEach(() => {
@@ -34,5 +35,38 @@ describe("ProjectDetailPage", () => {
 
     expect(await screen.findByText(/Project Details/i)).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /Payroll/i })).toBeInTheDocument();
+  });
+
+  it("posts allocations on save", async () => {
+    render(
+      <Provider>
+        <MemoryRouter initialEntries={["/dashboard/projects/1"]}>
+          <Routes>
+            <Route path="/dashboard/projects/:projectId" element={<ProjectDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    await screen.findByText(/Project Details/i);
+    fireEvent.click(screen.getByRole("tab", { name: /Payroll/i }));
+
+    fireEvent.change(screen.getAllByPlaceholderText(/Select Technician/i)[0], {
+      target: { value: "t1" },
+    });
+    fireEvent.change(screen.getAllByRole("spinbutton")[0], {
+      target: { value: "50" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Save Payroll/i }));
+
+    await screen.findByRole("button", { name: /Save Payroll/i });
+
+    expect((global.fetch as jest.Mock).mock.calls[2][0]).toContain(
+      "/rest/projects/1/accounts-payable"
+    );
+    expect((global.fetch as jest.Mock).mock.calls[2][1]).toMatchObject({
+      method: "POST",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- use `savePayroll` thunk in ProjectDetailPage
- allow client tests to run and add check for POSTing allocations

## Testing
- `npm test`
- `npx jest tests/client/pages/project-detail/ProjectDetailPage.test.tsx --runInBand --config client/jest.config.js` *(fails: No tests found)*