### PR TITLE
[VOLTA] include project status in accounts listing

### DIFF
--- a/server/src/controllers/rest/ProjectController.ts
+++ b/server/src/controllers/rest/ProjectController.ts
@@ -6,6 +6,7 @@ import { ProjectModel } from "../../models/ProjectModel";
 import { AccountsPayableModel } from "../../models/AccountsPayableModel";
 import { ProjectService, parseCSV, transformCSVToProject } from "../../services/ProjectService";
 import { SuccessArrayResult, SuccessResult } from "../../util/entities";
+import { AccountsByProjectResultModel } from "../../models/RestModels";
 
 @Controller("/projects")
 export class ProjectController {
@@ -63,9 +64,9 @@ export class ProjectController {
   }
 
   @Get("/accounts")
-  @Returns(200, SuccessArrayResult)
+  @(Returns(200, SuccessArrayResult).Of(AccountsByProjectResultModel))
   async listAccounts() {
     const res = await this.projectService.payableModelService.listAllByProject();
-    return { success: true, data: res };
+    return new SuccessArrayResult(res, AccountsByProjectResultModel);
   }
 }

--- a/server/src/models/RestModels.ts
+++ b/server/src/models/RestModels.ts
@@ -605,3 +605,18 @@ export class SaleRefResultModel {
   @Property() public readonly createdAt: Date;
   @Property() public readonly updatedAt: Date;
 }
+
+export class PayrollItemModel {
+  @Property() public readonly techId: string;
+  @Property() public readonly allocationPct: number;
+  @Property() public readonly paid: boolean;
+  @Property() public readonly amountDue: number;
+}
+
+export class AccountsByProjectResultModel {
+  @Property() public readonly projectId: string;
+  @Property() public readonly projectName: string;
+  @Property() public readonly status: string;
+  @CollectionOf(PayrollItemModel)
+  public readonly payroll: PayrollItemModel[];
+}

--- a/server/src/services/AccountsPayableService.ts
+++ b/server/src/services/AccountsPayableService.ts
@@ -56,10 +56,10 @@ export class AccountsPayableService {
   }
 
   public async listAllByProject() {
-    const projects = await this.payableModel
-      .find()
-      .populate('technicianId', 'name')
-      .populate('projectId', 'homeowner');
+      const projects = await this.payableModel
+        .find()
+        .populate('technicianId', 'name')
+        .populate('projectId', 'homeowner status');
     const map = new Map<string, any>();
     for (const rec of projects) {
       const pid = (rec.projectId as any)._id.toString();
@@ -67,6 +67,7 @@ export class AccountsPayableService {
         map.set(pid, {
           projectId: pid,
           projectName: (rec.projectId as any).homeowner,
+          status: (rec.projectId as any).status,
           payroll: [] as any[],
         });
       }

--- a/tests/server/services/AccountsPayableService.test.ts
+++ b/tests/server/services/AccountsPayableService.test.ts
@@ -47,4 +47,24 @@ describe('AccountsPayableService', () => {
     await service.markPaid('1');
     expect(payableModel.findByIdAndUpdate).toHaveBeenCalled();
   });
+
+  it('lists accounts grouped by project with status', async () => {
+    const docs = [
+      {
+        projectId: { _id: 'p1', homeowner: 'Home', status: 'Paid out' },
+        technicianId: { _id: 't1', name: 'Tech' },
+        percentage: 50,
+        paid: false,
+        amountDue: 100
+      }
+    ];
+    payableModel.find.mockReturnValue({
+      populate: jest.fn().mockReturnValue({
+        populate: jest.fn().mockResolvedValue(docs)
+      })
+    });
+
+    const res = await service.listAllByProject();
+    expect(res[0].status).toBe('Paid out');
+  });
 });


### PR DESCRIPTION
## Summary
- pull status from ProjectModel when listing accounts
- return the new AccountsByProjectResultModel via `/rest/projects/accounts`
- expose status in aggregated account lists
- test listAllByProject includes status field

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: Cannot find module '../source-code')*
- `npm --workspace server run test:lint` *(fails: eslint module error)*