### PR TITLE
[VOLTA] integrate payroll api hooks

### DIFF
--- a/client/src/pages/AccountsPayablePage.tsx
+++ b/client/src/pages/AccountsPayablePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import {
   Box,
   Heading,
@@ -11,21 +11,19 @@ import {
   Checkbox,
   useToast,
 } from "@chakra-ui/react";
-import { useAppDispatch, useAppSelector } from "../store";
-import { fetchUnpaid, markPaid } from "../store/accountsPayableSlice";
+import { useAppDispatch } from "../store";
+import { markPaid } from "../store/accountsPayableSlice";
+import { useGetAllPayrollQuery } from "../services/api";
 
 const AccountsPayablePage: React.FC = () => {
   const dispatch = useAppDispatch();
-  const records = useAppSelector((s) => s.accountsPayable.items);
+  const { data: records = [], refetch } = useGetAllPayrollQuery();
   const toast = useToast();
-
-  useEffect(() => {
-    dispatch(fetchUnpaid());
-  }, [dispatch]);
 
   const handlePaid = async (id: string) => {
     try {
       await dispatch(markPaid(id)).unwrap();
+      refetch();
       toast({
         title: "Marked as paid",
         status: "success",

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -22,10 +22,10 @@ import { useParams } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../store";
 import {
   fetchProjectById,
-  updateProjectPayroll,
   Project,
 } from "../store/projectsSlice";
 import { fetchUsers } from "../store/usersSlice";
+import { useAddPayrollMutation } from "../services/api";
 import PercentageInput from "../components/PercentageInput";
 
 const ProjectDetailPage: React.FC = () => {
@@ -145,22 +145,20 @@ const ProjectDetailPage: React.FC = () => {
     allocations.length === 0 ||
     allocations.reduce((s, a) => s + a.allocationPercent, 0) > 100;
 
-  const handleSave = () => {
+  const [addPayroll] = useAddPayrollMutation();
+
+  const handleSave = async () => {
     if (!projectId) return;
     const payroll = allocations.map((a) => ({
       technicianId: a.userId,
       percentage: a.allocationPercent,
-      paid: false,
     }));
 
-    dispatch(
-      updateProjectPayroll({
-        id: projectId,
-        payroll,
-        piecemealPercent:
-          typeof piecemealPercent === "number" ? piecemealPercent : 0,
-      })
-    );
+    try {
+      await addPayroll({ projectId, payroll }).unwrap();
+    } catch {
+      toast({ title: "Failed to save payroll", status: "error" });
+    }
   };
 
   return (

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,0 +1,40 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { baseURL } from '../apiConfig';
+
+export interface PayrollRecord {
+  _id: string;
+  projectId: string | { homeowner: string };
+  technicianId: string | { name: string };
+  percentage: number;
+  amountDue: number;
+  paid: boolean;
+}
+
+export const api = createApi({
+  reducerPath: 'api',
+  baseQuery: fetchBaseQuery({ baseUrl: `${baseURL}/rest` }),
+  tagTypes: ['Payroll'],
+  endpoints: (builder) => ({
+    getAllPayroll: builder.query<PayrollRecord[], void>({
+      query: () => '/payroll',
+      transformResponse: (res: { data: PayrollRecord[] }) => res.data.map((r: any) => ({
+        _id: r._id,
+        project: (r.projectId as any).homeowner,
+        technician: (r.technicianId as any).name,
+        allocationPct: r.percentage,
+        amountDue: r.amountDue,
+        paid: r.paid,
+      })),
+    }),
+    addPayroll: builder.mutation<void, { projectId: string; payroll: { technicianId: string; percentage: number }[] }>({
+      query: ({ projectId, payroll }) => ({
+        url: `/projects/${projectId}/payroll`,
+        method: 'POST',
+        body: { payroll },
+      }),
+      invalidatesTags: ['Payroll'],
+    }),
+  }),
+});
+
+export const { useGetAllPayrollQuery, useAddPayrollMutation } = api;

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -4,14 +4,18 @@ import projectsReducer from './projectsSlice'
 import usersReducer from './usersSlice'
 import accountsPayableReducer from './accountsPayableSlice'
 import { useDispatch, TypedUseSelectorHook, useSelector } from 'react-redux'
+import { api } from '../services/api'
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     projects: projectsReducer,
     users: usersReducer,
-    accountsPayable: accountsPayableReducer
-  }
+    accountsPayable: accountsPayableReducer,
+    [api.reducerPath]: api.reducer
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(api.middleware)
 })
 
 export type RootState = ReturnType<typeof store.getState>

--- a/tests/client/pages/accounts-payable/AccountsPayablePage.test.tsx
+++ b/tests/client/pages/accounts-payable/AccountsPayablePage.test.tsx
@@ -38,6 +38,6 @@ describe('AccountsPayablePage', () => {
 
     expect(await screen.findByText('Home')).toBeInTheDocument();
     expect(screen.getByText('Upcoming')).toBeInTheDocument();
-    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('/rest/accounts-payable');
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('/rest/payroll');
   });
 });

--- a/tests/client/pages/project-detail/ProjectDetailPage.test.tsx
+++ b/tests/client/pages/project-detail/ProjectDetailPage.test.tsx
@@ -63,7 +63,7 @@ describe("ProjectDetailPage", () => {
     await screen.findByRole("button", { name: /Save Payroll/i });
 
     expect((global.fetch as jest.Mock).mock.calls[2][0]).toContain(
-      "/rest/projects/1/accounts-payable"
+      "/rest/projects/1/payroll"
     );
     expect((global.fetch as jest.Mock).mock.calls[2][1]).toMatchObject({
       method: "POST",


### PR DESCRIPTION
## Summary
- add RTK query service for payroll endpoints
- fetch payroll via RTK query in AccountsPayablePage
- submit payroll allocations with useAddPayrollMutation
- wire API service middleware into Redux store
- update related tests

## Testing
- `JEST_CONFIG=jest.config.js npx react-scripts test --watchAll=false` *(fails: Cannot find module '@chakra-ui/utils/context')*
- `npm run test:server`