### PR TITLE
[VOLTA] include project and technician names in payroll

### DIFF
--- a/server/src/services/PayrollService.ts
+++ b/server/src/services/PayrollService.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from "@tsed/di";
 import { MongooseModel } from "@tsed/mongoose";
 import { PayrollModel } from "../models/PayrollModel";
 import { ProjectModel } from "../models/ProjectModel";
+import { AdminModel } from "../models/AdminModel";
 
 interface PayrollEntry {
   technicianId: string;
@@ -12,18 +13,32 @@ interface PayrollEntry {
 export class PayrollService {
   constructor(
     @Inject(PayrollModel) private payrollModel: MongooseModel<PayrollModel>,
-    @Inject(ProjectModel) private projectModel: MongooseModel<ProjectModel>
+    @Inject(ProjectModel) private projectModel: MongooseModel<ProjectModel>,
+    @Inject(AdminModel) private adminModel: MongooseModel<AdminModel>
   ) {}
 
   async insert(projectId: string, entries: PayrollEntry[]) {
     const project = await this.projectModel.findById(projectId).lean();
     const contract = project?.contractAmount || 0;
+    const projectName = project?.homeowner || "Unknown";
+
+    const techIds = [...new Set(entries.map((e) => e.technicianId))];
+    const technicians = await this.adminModel
+      .find({ _id: { $in: techIds } })
+      .lean();
+    const techMap = new Map(
+      technicians.map((t) => [t._id.toString(), t.name as string])
+    );
+
     const results: PayrollModel[] = [];
     for (const entry of entries) {
       const amountDue = (contract * entry.percentage) / 100;
+      const technicianName = techMap.get(entry.technicianId) || "Unknown";
       const doc = await this.payrollModel.create({
         projectId,
         technicianId: entry.technicianId,
+        technicianName,
+        projectName,
         percentage: entry.percentage,
         amountDue,
         paid: false


### PR DESCRIPTION
## Summary
- fetch project and technician details when creating payroll
- store technicianName and projectName in payroll records

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683a656714388321af8f8ee641f97814